### PR TITLE
feat: 웹뷰를 통한 파싱 구현 (#90)

### DIFF
--- a/app/src/main/java/com/scrap2025/scrap2025/ui/common/components/WebViewScrapDialog.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/common/components/WebViewScrapDialog.kt
@@ -1,0 +1,219 @@
+package com.scrap2025.scrap2025.ui.common.components
+
+import android.graphics.Bitmap
+import android.util.Log
+import android.webkit.JavascriptInterface
+import android.webkit.WebChromeClient
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.scrap2025.scrap2025.model.LinkPreview
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+// Data class for parsing JSON returned from JS
+@Serializable
+data class ParsedMetadata(
+    val title: String? = null,
+    val description: String? = null,
+    val imageUrl: String? = null
+)
+
+@Composable
+fun WebViewScrapDialog(url: String, onDismiss: () -> Unit, onScrapComplete: (LinkPreview) -> Unit) {
+    var isLoading by remember { mutableStateOf(true) }
+    var progress by remember { mutableStateOf(0.0f) }
+    var hasError by remember { mutableStateOf(false) }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false) // Use full screen
+    ) {
+        Column(modifier = Modifier
+            .fillMaxSize()
+            .background(Color.White)) {
+            // Top Toolbar
+            Box(modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp)
+                .background(Color(0xFFF5F5F5))) {
+                IconButton(onClick = onDismiss, modifier = Modifier.align(Alignment.CenterStart)) {
+                    Icon(Icons.Default.Close, contentDescription = "Close")
+                }
+
+                Text(text = "직접 확인해서 추가하기", modifier = Modifier.align(Alignment.Center))
+            }
+
+            // Loading Bar
+            if (isLoading) {
+                LinearProgressIndicator(
+                    progress = { progress },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+
+            // WebView Area
+            AndroidView(
+                modifier = Modifier.fillMaxSize(),
+                factory = { context ->
+                    WebView(context).apply {
+                        settings.javaScriptEnabled = true
+                        settings.domStorageEnabled = true
+                        settings.userAgentString =
+                            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36" // Desktop Chrome
+
+                        // Register JS Interface
+                        addJavascriptInterface(
+                            object {
+                                @JavascriptInterface
+                                fun processMetadata(jsonString: String) {
+                                    Log.d(
+                                        "WebViewScrap",
+                                        "processMetadata called with: $jsonString"
+                                    )
+                                    try {
+                                        val metadata =
+                                            Json { ignoreUnknownKeys = true }
+                                                .decodeFromString<ParsedMetadata>(
+                                                    jsonString
+                                                )
+                                        Log.d("WebViewScrap", "Parsed metadata: $metadata")
+                                        val preview =
+                                            LinkPreview(
+                                                url = url,
+                                                title = metadata.title ?: url,
+                                                description = metadata.description
+                                                    ?: "",
+                                                imageUrl = metadata.imageUrl,
+                                                siteName = null
+                                            )
+                                        // Callback on Main Thread
+                                        post {
+                                            Log.d("WebViewScrap", "Posting onScrapComplete")
+                                            onScrapComplete(preview)
+                                        }
+                                    } catch (e: Exception) {
+                                        Log.e("WebViewScrap", "Metadata parsing failed", e)
+                                    }
+                                }
+                            },
+                            "AndroidApp"
+                        )
+
+                        webViewClient =
+                            object : WebViewClient() {
+                                override fun onPageStarted(
+                                    view: WebView?,
+                                    url: String?,
+                                    favicon: Bitmap?
+                                ) {
+                                    Log.d("WebViewScrap", "onPageStarted: $url")
+                                    isLoading = true
+                                    hasError = false
+                                }
+
+                                override fun onPageFinished(view: WebView?, url: String?) {
+                                    Log.d("WebViewScrap", "onPageFinished: $url")
+                                    isLoading = false
+                                    if (!hasError) {
+                                        // Inject JS to extract metadata ONLY if no error
+                                        // occurred
+                                        extractMetadata(this@apply)
+                                    }
+                                }
+
+                                override fun onReceivedError(
+                                    view: WebView?,
+                                    request: WebResourceRequest?,
+                                    error: WebResourceError?
+                                ) {
+                                    super.onReceivedError(view, request, error)
+                                    Log.e(
+                                        "WebViewScrap",
+                                        "onReceivedError: ${error?.description}, errorCode: ${error?.errorCode}"
+                                    )
+                                    hasError = true
+                                }
+
+                                override fun onReceivedHttpError(
+                                    view: WebView?,
+                                    request: WebResourceRequest?,
+                                    errorResponse: WebResourceResponse?
+                                ) {
+                                    super.onReceivedHttpError(view, request, errorResponse)
+                                    Log.e(
+                                        "WebViewScrap",
+                                        "onReceivedHttpError: ${errorResponse?.statusCode}"
+                                    )
+                                    hasError = true
+                                }
+                            }
+
+                        webChromeClient =
+                            object : WebChromeClient() {
+                                override fun onProgressChanged(
+                                    view: WebView?,
+                                    newProgress: Int
+                                ) {
+                                    progress = newProgress / 100f
+                                }
+                            }
+
+                        Log.d("WebViewScrap", "Loading URL: $url")
+                        loadUrl(url)
+                    }
+                }
+            )
+        }
+    }
+}
+
+// JS Script for metadata extraction
+private fun extractMetadata(webView: WebView) {
+    val script =
+        """
+        (function() {
+            var ogTitle = document.querySelector('meta[property="og:title"]')?.content;
+            var ogImage = document.querySelector('meta[property="og:image"]')?.content;
+            var ogDesc = document.querySelector('meta[property="og:description"]')?.content;
+            var title = document.title;
+            
+            var data = {
+                title: ogTitle || title,
+                imageUrl: ogImage,
+                description: ogDesc
+            };
+            
+            // Call AndroidApp Interface
+            window.AndroidApp.processMetadata(JSON.stringify(data));
+        })();
+    """.trimIndent()
+
+    webView.evaluateJavascript(script, null)
+}

--- a/app/src/main/java/com/scrap2025/scrap2025/ui/common/components/WebViewScrapDialog.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/common/components/WebViewScrapDialog.kt
@@ -201,17 +201,57 @@ fun WebViewScrapDialog(url: String, onDismiss: () -> Unit, onScrapComplete: (Lin
                                         request: WebResourceRequest?
                                     ): Boolean {
                                         val url = request?.url?.toString() ?: return false
-                                        return if (url.startsWith("http://") ||
+
+                                        if (url.startsWith("http://") ||
                                             url.startsWith("https://")
                                         ) {
-                                            false
-                                        } else {
-                                            Log.d(
-                                                "WebViewScrap",
-                                                "Blocked URL scheme: $url"
-                                            )
-                                            true
+                                            return false
                                         }
+
+                                        // Handle intent:// schemes
+                                        if (url.startsWith("intent://")) {
+                                            try {
+                                                // Extract fallback URL manually to avoid
+                                                // Android dependency issues in this scope
+                                                // if possible,
+                                                // but using string parsing is reliable for
+                                                // the standard format.
+                                                // Format:
+                                                // intent://...?#Intent;...;S.browser_fallback_url=...;end
+                                                val fallbackUrl =
+                                                    url.substringAfter(
+                                                        "S.browser_fallback_url=",
+                                                        ""
+                                                    )
+                                                        .substringBefore(";")
+
+                                                if (fallbackUrl.isNotEmpty()) {
+                                                    // Decode if necessary
+                                                    // (browser_fallback_url is often
+                                                    // URL-encoded)
+                                                    val decodedUrl =
+                                                        java.net.URLDecoder.decode(
+                                                            fallbackUrl,
+                                                            "UTF-8"
+                                                        )
+                                                    Log.d(
+                                                        "WebViewScrap",
+                                                        "Redirecting to fallback URL: $decodedUrl"
+                                                    )
+                                                    view?.loadUrl(decodedUrl)
+                                                    return true // Handled by manual load
+                                                }
+                                            } catch (e: Exception) {
+                                                Log.e(
+                                                    "WebViewScrap",
+                                                    "Failed to parse intent fallback",
+                                                    e
+                                                )
+                                            }
+                                        }
+
+                                        Log.d("WebViewScrap", "Blocked URL scheme: $url")
+                                        return true
                                     }
 
                                     override fun onReceivedError(

--- a/app/src/main/java/com/scrap2025/scrap2025/ui/common/components/WebViewScrapDialog.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/common/components/WebViewScrapDialog.kt
@@ -59,7 +59,7 @@ fun WebViewScrapDialog(url: String, onDismiss: () -> Unit, onScrapComplete: (Lin
     var isInitialLoad by remember { mutableStateOf(true) }
 
     LaunchedEffect(Unit) {
-        delay(2000) // Hide redirects for 2 seconds
+        delay(2500) // Hide redirects for 2 seconds
         isInitialLoad = false
     }
 

--- a/app/src/main/java/com/scrap2025/scrap2025/ui/common/components/WebViewScrapDialog.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/common/components/WebViewScrapDialog.kt
@@ -18,12 +18,14 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -36,6 +38,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.scrap2025.scrap2025.model.LinkPreview
+import kotlinx.coroutines.delay
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
@@ -53,6 +56,12 @@ fun WebViewScrapDialog(url: String, onDismiss: () -> Unit, onScrapComplete: (Lin
     var progress by remember { mutableStateOf(0.0f) }
     var hasError by remember { mutableStateOf(false) }
     var webViewRef by remember { mutableStateOf<WebView?>(null) }
+    var isInitialLoad by remember { mutableStateOf(true) }
+
+    LaunchedEffect(Unit) {
+        delay(2000) // Hide redirects for 2 seconds
+        isInitialLoad = false
+    }
 
     Dialog(
         onDismissRequest = onDismiss,
@@ -91,136 +100,182 @@ fun WebViewScrapDialog(url: String, onDismiss: () -> Unit, onScrapComplete: (Lin
                 }
             }
 
-            // Loading Bar
-            if (isLoading) {
+            // Loading Bar (Shows during page loads OR during initial 2s delay)
+            if (isLoading || isInitialLoad) {
                 LinearProgressIndicator(
-                    progress = { progress },
+                    progress = {
+                        if (isInitialLoad) 0.5f else progress
+                    }, // Fake progress for initial delay
                     modifier = Modifier.fillMaxWidth(),
                 )
             }
 
             // WebView Area
-            AndroidView(
-                modifier = Modifier.fillMaxSize(),
-                factory = { context ->
-                    WebView(context).apply {
-                        webViewRef = this
-                        settings.javaScriptEnabled = true
-                        settings.domStorageEnabled = true
+            // WebView and Overlay Container
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+            ) {
+                AndroidView(
+                    modifier = Modifier.fillMaxSize(),
+                    factory = { context ->
+                        WebView(context).apply {
+                            webViewRef = this
+                            settings.javaScriptEnabled = true
+                            settings.domStorageEnabled = true
 
-                        // Register JS Interface
-                        addJavascriptInterface(
-                            object {
-                                @JavascriptInterface
-                                fun processMetadata(jsonString: String) {
-                                    Log.d(
-                                        "WebViewScrap",
-                                        "processMetadata called with: $jsonString"
-                                    )
-                                    try {
-                                        val metadata =
-                                            Json { ignoreUnknownKeys = true }
-                                                .decodeFromString<ParsedMetadata>(
-                                                    jsonString
-                                                )
-                                        Log.d("WebViewScrap", "Parsed metadata: $metadata")
-                                        val preview =
-                                            LinkPreview(
-                                                url = url,
-                                                title = metadata.title ?: url,
-                                                description = metadata.description
-                                                    ?: "",
-                                                imageUrl = metadata.imageUrl,
-                                                siteName = null
+                            // Register JS Interface
+                            addJavascriptInterface(
+                                object {
+                                    @JavascriptInterface
+                                    fun processMetadata(jsonString: String) {
+                                        Log.d(
+                                            "WebViewScrap",
+                                            "processMetadata called with: $jsonString"
+                                        )
+                                        try {
+                                            val metadata =
+                                                Json { ignoreUnknownKeys = true }
+                                                    .decodeFromString<
+                                                            ParsedMetadata>(
+                                                        jsonString
+                                                    )
+                                            Log.d(
+                                                "WebViewScrap",
+                                                "Parsed metadata: $metadata"
                                             )
-                                        // Callback on Main Thread
-                                        post {
-                                            Log.d("WebViewScrap", "Posting onScrapComplete")
-                                            onScrapComplete(preview)
+                                            val preview =
+                                                LinkPreview(
+                                                    url = url,
+                                                    title = metadata.title ?: url,
+                                                    description =
+                                                        metadata.description
+                                                            ?: "",
+                                                    imageUrl = metadata.imageUrl,
+                                                    siteName = null
+                                                )
+                                            // Callback on Main Thread
+                                            post {
+                                                Log.d(
+                                                    "WebViewScrap",
+                                                    "Posting onScrapComplete"
+                                                )
+                                                onScrapComplete(preview)
+                                            }
+                                        } catch (e: Exception) {
+                                            Log.e(
+                                                "WebViewScrap",
+                                                "Metadata parsing failed",
+                                                e
+                                            )
                                         }
-                                    } catch (e: Exception) {
-                                        Log.e("WebViewScrap", "Metadata parsing failed", e)
                                     }
-                                }
-                            },
-                            "AndroidApp"
-                        )
+                                },
+                                "AndroidApp"
+                            )
 
-                        webViewClient =
-                            object : WebViewClient() {
-                                override fun onPageStarted(
-                                    view: WebView?,
-                                    url: String?,
-                                    favicon: Bitmap?
-                                ) {
-                                    Log.d("WebViewScrap", "onPageStarted: $url")
-                                    isLoading = true
-                                    hasError = false
-                                }
-
-                                override fun onPageFinished(view: WebView?, url: String?) {
-                                    Log.d("WebViewScrap", "onPageFinished: $url")
-                                    isLoading = false
-                                    // Auto-extract removed. User must click 'Import'
-                                }
-
-                                override fun shouldOverrideUrlLoading(
-                                    view: WebView?,
-                                    request: WebResourceRequest?
-                                ): Boolean {
-                                    val url = request?.url?.toString() ?: return false
-                                    return if (url.startsWith("http://") ||
-                                        url.startsWith("https://")
+                            webViewClient =
+                                object : WebViewClient() {
+                                    override fun onPageStarted(
+                                        view: WebView?,
+                                        url: String?,
+                                        favicon: Bitmap?
                                     ) {
-                                        false
-                                    } else {
-                                        Log.d("WebViewScrap", "Blocked URL scheme: $url")
-                                        true
+                                        Log.d("WebViewScrap", "onPageStarted: $url")
+                                        isLoading = true
+                                        hasError = false
+                                    }
+
+                                    override fun onPageFinished(
+                                        view: WebView?,
+                                        url: String?
+                                    ) {
+                                        Log.d("WebViewScrap", "onPageFinished: $url")
+                                        isLoading = false
+                                        // Auto-extract removed. User must click 'Import'
+                                    }
+
+                                    override fun shouldOverrideUrlLoading(
+                                        view: WebView?,
+                                        request: WebResourceRequest?
+                                    ): Boolean {
+                                        val url = request?.url?.toString() ?: return false
+                                        return if (url.startsWith("http://") ||
+                                            url.startsWith("https://")
+                                        ) {
+                                            false
+                                        } else {
+                                            Log.d(
+                                                "WebViewScrap",
+                                                "Blocked URL scheme: $url"
+                                            )
+                                            true
+                                        }
+                                    }
+
+                                    override fun onReceivedError(
+                                        view: WebView?,
+                                        request: WebResourceRequest?,
+                                        error: WebResourceError?
+                                    ) {
+                                        super.onReceivedError(view, request, error)
+                                        Log.e(
+                                            "WebViewScrap",
+                                            "onReceivedError: ${error?.description}, errorCode: ${error?.errorCode}"
+                                        )
+                                        hasError = true
+                                    }
+
+                                    override fun onReceivedHttpError(
+                                        view: WebView?,
+                                        request: WebResourceRequest?,
+                                        errorResponse: WebResourceResponse?
+                                    ) {
+                                        super.onReceivedHttpError(
+                                            view,
+                                            request,
+                                            errorResponse
+                                        )
+                                        Log.e(
+                                            "WebViewScrap",
+                                            "onReceivedHttpError: ${errorResponse?.statusCode}"
+                                        )
+                                        hasError = true
                                     }
                                 }
 
-                                override fun onReceivedError(
-                                    view: WebView?,
-                                    request: WebResourceRequest?,
-                                    error: WebResourceError?
-                                ) {
-                                    super.onReceivedError(view, request, error)
-                                    Log.e(
-                                        "WebViewScrap",
-                                        "onReceivedError: ${error?.description}, errorCode: ${error?.errorCode}"
-                                    )
-                                    hasError = true
+                            webChromeClient =
+                                object : WebChromeClient() {
+                                    override fun onProgressChanged(
+                                        view: WebView?,
+                                        newProgress: Int
+                                    ) {
+                                        progress = newProgress / 100f
+                                    }
                                 }
 
-                                override fun onReceivedHttpError(
-                                    view: WebView?,
-                                    request: WebResourceRequest?,
-                                    errorResponse: WebResourceResponse?
-                                ) {
-                                    super.onReceivedHttpError(view, request, errorResponse)
-                                    Log.e(
-                                        "WebViewScrap",
-                                        "onReceivedHttpError: ${errorResponse?.statusCode}"
-                                    )
-                                    hasError = true
-                                }
-                            }
+                            Log.d("WebViewScrap", "Loading URL: $url")
+                            loadUrl(url)
+                        }
+                    }
+                )
 
-                        webChromeClient =
-                            object : WebChromeClient() {
-                                override fun onProgressChanged(
-                                    view: WebView?,
-                                    newProgress: Int
-                                ) {
-                                    progress = newProgress / 100f
-                                }
-                            }
-
-                        Log.d("WebViewScrap", "Loading URL: $url")
-                        loadUrl(url)
+                // Full screen overlay for initial load to hide redirects
+                if (isInitialLoad) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(Color.White),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            CircularProgressIndicator(color = Color.Black)
+                            Text(text = "페이지 연결 중...", modifier = Modifier.padding(top = 16.dp))
+                        }
                     }
                 }
-            )
+            }
         }
     }
 }

--- a/app/src/main/java/com/scrap2025/scrap2025/ui/common/components/WebViewScrapDialog.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/common/components/WebViewScrapDialog.kt
@@ -15,12 +15,14 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -50,24 +52,43 @@ fun WebViewScrapDialog(url: String, onDismiss: () -> Unit, onScrapComplete: (Lin
     var isLoading by remember { mutableStateOf(true) }
     var progress by remember { mutableStateOf(0.0f) }
     var hasError by remember { mutableStateOf(false) }
+    var webViewRef by remember { mutableStateOf<WebView?>(null) }
 
     Dialog(
         onDismissRequest = onDismiss,
         properties = DialogProperties(usePlatformDefaultWidth = false) // Use full screen
     ) {
-        Column(modifier = Modifier
-            .fillMaxSize()
-            .background(Color.White)) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.White)
+        ) {
             // Top Toolbar
-            Box(modifier = Modifier
-                .fillMaxWidth()
-                .height(56.dp)
-                .background(Color(0xFFF5F5F5))) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+                    .background(Color(0xFFF5F5F5))
+            ) {
                 IconButton(onClick = onDismiss, modifier = Modifier.align(Alignment.CenterStart)) {
                     Icon(Icons.Default.Close, contentDescription = "Close")
                 }
 
                 Text(text = "직접 확인해서 추가하기", modifier = Modifier.align(Alignment.Center))
+
+                // Manual Trigger Button
+                TextButton(
+                    onClick = { webViewRef?.let { extractMetadata(it) } },
+                    modifier = Modifier
+                        .align(Alignment.CenterEnd)
+                        .padding(end = 8.dp)
+                ) {
+                    Text(
+                        text = "가져오기",
+                        color = Color.Blue // Or MainColor if available, using standard Color
+                        // for now to avoid dependency lookup if not imported
+                    )
+                }
             }
 
             // Loading Bar
@@ -83,10 +104,9 @@ fun WebViewScrapDialog(url: String, onDismiss: () -> Unit, onScrapComplete: (Lin
                 modifier = Modifier.fillMaxSize(),
                 factory = { context ->
                     WebView(context).apply {
+                        webViewRef = this
                         settings.javaScriptEnabled = true
                         settings.domStorageEnabled = true
-                        settings.userAgentString =
-                            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36" // Desktop Chrome
 
                         // Register JS Interface
                         addJavascriptInterface(
@@ -141,10 +161,21 @@ fun WebViewScrapDialog(url: String, onDismiss: () -> Unit, onScrapComplete: (Lin
                                 override fun onPageFinished(view: WebView?, url: String?) {
                                     Log.d("WebViewScrap", "onPageFinished: $url")
                                     isLoading = false
-                                    if (!hasError) {
-                                        // Inject JS to extract metadata ONLY if no error
-                                        // occurred
-                                        extractMetadata(this@apply)
+                                    // Auto-extract removed. User must click 'Import'
+                                }
+
+                                override fun shouldOverrideUrlLoading(
+                                    view: WebView?,
+                                    request: WebResourceRequest?
+                                ): Boolean {
+                                    val url = request?.url?.toString() ?: return false
+                                    return if (url.startsWith("http://") ||
+                                        url.startsWith("https://")
+                                    ) {
+                                        false
+                                    } else {
+                                        Log.d("WebViewScrap", "Blocked URL scheme: $url")
+                                        true
                                     }
                                 }
 

--- a/app/src/main/java/com/scrap2025/scrap2025/ui/common/components/WebViewScrapDialog.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/common/components/WebViewScrapDialog.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
@@ -38,6 +37,9 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.scrap2025.scrap2025.model.LinkPreview
+import com.scrap2025.scrap2025.ui.theme.BackgroundColor
+import com.scrap2025.scrap2025.ui.theme.MainColorDeep
+import com.scrap2025.scrap2025.ui.theme.MainColorLight
 import kotlinx.coroutines.delay
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -50,6 +52,8 @@ data class ParsedMetadata(
     val imageUrl: String? = null
 )
 
+private const val TAG = "WebViewScrap"
+
 @Composable
 fun WebViewScrapDialog(url: String, onDismiss: () -> Unit, onScrapComplete: (LinkPreview) -> Unit) {
     var isLoading by remember { mutableStateOf(true) }
@@ -59,7 +63,7 @@ fun WebViewScrapDialog(url: String, onDismiss: () -> Unit, onScrapComplete: (Lin
     var isInitialLoad by remember { mutableStateOf(true) }
 
     LaunchedEffect(Unit) {
-        delay(2500) // Hide redirects for 2 seconds
+        delay(2500) // Hide redirects for 2.5 seconds
         isInitialLoad = false
     }
 
@@ -67,56 +71,13 @@ fun WebViewScrapDialog(url: String, onDismiss: () -> Unit, onScrapComplete: (Lin
         onDismissRequest = onDismiss,
         properties = DialogProperties(usePlatformDefaultWidth = false) // Use full screen
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(Color.White)
-        ) {
-            // Top Toolbar
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(56.dp)
-                    .background(Color(0xFFF5F5F5))
-            ) {
-                IconButton(onClick = onDismiss, modifier = Modifier.align(Alignment.CenterStart)) {
-                    Icon(Icons.Default.Close, contentDescription = "Close")
-                }
-
-                Text(text = "직접 확인해서 추가하기", modifier = Modifier.align(Alignment.Center))
-
-                // Manual Trigger Button
-                TextButton(
-                    onClick = { webViewRef?.let { extractMetadata(it) } },
-                    modifier = Modifier
-                        .align(Alignment.CenterEnd)
-                        .padding(end = 8.dp)
-                ) {
-                    Text(
-                        text = "가져오기",
-                        color = Color.Blue // Or MainColor if available, using standard Color
-                        // for now to avoid dependency lookup if not imported
-                    )
-                }
-            }
-
-            // Loading Bar (Shows during page loads OR during initial 2s delay)
-            if (isLoading || isInitialLoad) {
-                LinearProgressIndicator(
-                    progress = {
-                        if (isInitialLoad) 0.5f else progress
-                    }, // Fake progress for initial delay
-                    modifier = Modifier.fillMaxWidth(),
-                )
-            }
-
-            // WebView Area
-            // WebView and Overlay Container
-            Box(
-                modifier = Modifier
-                    .weight(1f)
-                    .fillMaxWidth()
-            ) {
+        WebViewScrapDialogContent(
+            title = "직접 확인해서 가져오기",
+            onDismiss = onDismiss,
+            onImport = { webViewRef?.let { extractMetadata(it) } },
+            isLoading = isLoading || isInitialLoad,
+            progress = if (isInitialLoad) 0.5f else progress,
+            webViewContent = {
                 AndroidView(
                     modifier = Modifier.fillMaxSize(),
                     factory = { context ->
@@ -130,191 +91,203 @@ fun WebViewScrapDialog(url: String, onDismiss: () -> Unit, onScrapComplete: (Lin
                                 object {
                                     @JavascriptInterface
                                     fun processMetadata(jsonString: String) {
-                                        Log.d(
-                                            "WebViewScrap",
-                                            "processMetadata called with: $jsonString"
-                                        )
+                                        Log.d(TAG, "processMetadata called with: $jsonString")
                                         try {
-                                            val metadata =
-                                                Json { ignoreUnknownKeys = true }
-                                                    .decodeFromString<
-                                                            ParsedMetadata>(
-                                                        jsonString
-                                                    )
-                                            Log.d(
-                                                "WebViewScrap",
-                                                "Parsed metadata: $metadata"
+                                            val metadata = Json { ignoreUnknownKeys = true
+                                            }.decodeFromString<ParsedMetadata>(jsonString)
+
+                                            Log.d(TAG, "Parsed metadata: $metadata")
+
+                                            val preview = LinkPreview(
+                                                url = url,
+                                                title = metadata.title ?: url,
+                                                description = metadata.description ?: "",
+                                                imageUrl = metadata.imageUrl,
+                                                siteName = null
                                             )
-                                            val preview =
-                                                LinkPreview(
-                                                    url = url,
-                                                    title = metadata.title ?: url,
-                                                    description =
-                                                        metadata.description
-                                                            ?: "",
-                                                    imageUrl = metadata.imageUrl,
-                                                    siteName = null
-                                                )
+
                                             // Callback on Main Thread
                                             post {
-                                                Log.d(
-                                                    "WebViewScrap",
-                                                    "Posting onScrapComplete"
+                                                Log.d(TAG, "Posting onScrapComplete"
                                                 )
                                                 onScrapComplete(preview)
                                             }
                                         } catch (e: Exception) {
-                                            Log.e(
-                                                "WebViewScrap",
-                                                "Metadata parsing failed",
-                                                e
-                                            )
+                                            Log.e(TAG, "Metadata parsing failed", e)
                                         }
                                     }
-                                },
-                                "AndroidApp"
+                                }, "AndroidApp"
                             )
 
-                            webViewClient =
-                                object : WebViewClient() {
-                                    override fun onPageStarted(
-                                        view: WebView?,
-                                        url: String?,
-                                        favicon: Bitmap?
-                                    ) {
-                                        Log.d("WebViewScrap", "onPageStarted: $url")
-                                        isLoading = true
-                                        hasError = false
+                            webViewClient = object : WebViewClient() {
+                                override fun onPageStarted(
+                                    view: WebView?, url: String?, favicon: Bitmap?
+                                ) {
+                                    Log.d(TAG, "onPageStarted: $url")
+
+                                    isLoading = true
+                                    hasError = false
+                                }
+
+                                override fun onPageFinished(
+                                    view: WebView?, url: String?
+                                ) {
+                                    Log.d(TAG, "onPageFinished: $url")
+
+                                    isLoading = false
+                                }
+
+                                override fun shouldOverrideUrlLoading(
+                                    view: WebView?, request: WebResourceRequest?
+                                ): Boolean {
+                                    val url = request?.url?.toString() ?: return false
+
+                                    if (url.startsWith("http://") || url.startsWith("https://")) {
+                                        return false
                                     }
 
-                                    override fun onPageFinished(
-                                        view: WebView?,
-                                        url: String?
-                                    ) {
-                                        Log.d("WebViewScrap", "onPageFinished: $url")
-                                        isLoading = false
-                                        // Auto-extract removed. User must click 'Import'
-                                    }
+                                    // Handle intent:// schemes
+                                    if (url.startsWith("intent://")) {
+                                        try {
+                                            // Extract fallback URL manually
+                                            val fallbackUrl = url.substringAfter(
+                                                "S.browser_fallback_url=", ""
+                                            ).substringBefore(";")
 
-                                    override fun shouldOverrideUrlLoading(
-                                        view: WebView?,
-                                        request: WebResourceRequest?
-                                    ): Boolean {
-                                        val url = request?.url?.toString() ?: return false
-
-                                        if (url.startsWith("http://") ||
-                                            url.startsWith("https://")
-                                        ) {
-                                            return false
-                                        }
-
-                                        // Handle intent:// schemes
-                                        if (url.startsWith("intent://")) {
-                                            try {
-                                                // Extract fallback URL manually to avoid
-                                                // Android dependency issues in this scope
-                                                // if possible,
-                                                // but using string parsing is reliable for
-                                                // the standard format.
-                                                // Format:
-                                                // intent://...?#Intent;...;S.browser_fallback_url=...;end
-                                                val fallbackUrl =
-                                                    url.substringAfter(
-                                                        "S.browser_fallback_url=",
-                                                        ""
-                                                    )
-                                                        .substringBefore(";")
-
-                                                if (fallbackUrl.isNotEmpty()) {
-                                                    // Decode if necessary
-                                                    // (browser_fallback_url is often
-                                                    // URL-encoded)
-                                                    val decodedUrl =
-                                                        java.net.URLDecoder.decode(
-                                                            fallbackUrl,
-                                                            "UTF-8"
-                                                        )
-                                                    Log.d(
-                                                        "WebViewScrap",
-                                                        "Redirecting to fallback URL: $decodedUrl"
-                                                    )
-                                                    view?.loadUrl(decodedUrl)
-                                                    return true // Handled by manual load
-                                                }
-                                            } catch (e: Exception) {
-                                                Log.e(
-                                                    "WebViewScrap",
-                                                    "Failed to parse intent fallback",
-                                                    e
+                                            if (fallbackUrl.isNotEmpty()) {
+                                                // Decode if necessary
+                                                // (browser_fallback_url is often
+                                                // URL-encoded)
+                                                val decodedUrl = java.net.URLDecoder.decode(
+                                                    fallbackUrl, "UTF-8"
                                                 )
+                                                Log.d(TAG, "Redirecting to fallback URL: $decodedUrl")
+
+                                                view?.loadUrl(decodedUrl)
+                                                return true // Handled by manual load
                                             }
+                                        } catch (e: Exception) {
+                                            Log.e(TAG, "Failed to parse intent fallback", e)
                                         }
-
-                                        Log.d("WebViewScrap", "Blocked URL scheme: $url")
-                                        return true
                                     }
 
-                                    override fun onReceivedError(
-                                        view: WebView?,
-                                        request: WebResourceRequest?,
-                                        error: WebResourceError?
-                                    ) {
-                                        super.onReceivedError(view, request, error)
-                                        Log.e(
-                                            "WebViewScrap",
-                                            "onReceivedError: ${error?.description}, errorCode: ${error?.errorCode}"
-                                        )
-                                        hasError = true
-                                    }
-
-                                    override fun onReceivedHttpError(
-                                        view: WebView?,
-                                        request: WebResourceRequest?,
-                                        errorResponse: WebResourceResponse?
-                                    ) {
-                                        super.onReceivedHttpError(
-                                            view,
-                                            request,
-                                            errorResponse
-                                        )
-                                        Log.e(
-                                            "WebViewScrap",
-                                            "onReceivedHttpError: ${errorResponse?.statusCode}"
-                                        )
-                                        hasError = true
-                                    }
+                                    Log.d(TAG, "Blocked URL scheme: $url")
+                                    return true
                                 }
 
-                            webChromeClient =
-                                object : WebChromeClient() {
-                                    override fun onProgressChanged(
-                                        view: WebView?,
-                                        newProgress: Int
-                                    ) {
-                                        progress = newProgress / 100f
-                                    }
+                                override fun onReceivedError(
+                                    view: WebView?,
+                                    request: WebResourceRequest?,
+                                    error: WebResourceError?
+                                ) {
+                                    super.onReceivedError(view, request, error)
+                                    Log.e(TAG, "onReceivedError: ${error?.description}, errorCode: ${error?.errorCode}")
+                                    hasError = true
                                 }
 
-                            Log.d("WebViewScrap", "Loading URL: $url")
+                                override fun onReceivedHttpError(
+                                    view: WebView?,
+                                    request: WebResourceRequest?,
+                                    errorResponse: WebResourceResponse?
+                                ) {
+                                    super.onReceivedHttpError(
+                                        view, request, errorResponse
+                                    )
+                                    Log.e(TAG, "onReceivedHttpError: ${errorResponse?.statusCode}")
+                                    hasError = true
+                                }
+                            }
+
+                            webChromeClient = object : WebChromeClient() {
+                                override fun onProgressChanged(
+                                    view: WebView?,
+                                    newProgress: Int
+                                ) {
+                                    progress = newProgress / 100f
+                                }
+                            }
+
+                            Log.d(TAG, "Loading URL: $url")
                             loadUrl(url)
                         }
                     }
                 )
+            })
+    }
+}
 
-                // Full screen overlay for initial load to hide redirects
-                if (isInitialLoad) {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .background(Color.White),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                            CircularProgressIndicator(color = Color.Black)
-                            Text(text = "페이지 연결 중...", modifier = Modifier.padding(top = 16.dp))
-                        }
-                    }
-                }
+/**
+ * WebViewScrapDialogContent: UI 전용 Composable
+ * - Preview 가능하도록 로직과 분리됨
+ * - Slot API(webViewContent)를 통해 실제 WebView 또는 가짜 박스를 주입받음
+ */
+@Composable
+fun WebViewScrapDialogContent(
+    title: String,
+    onDismiss: () -> Unit,
+    onImport: () -> Unit,
+    isLoading: Boolean,
+    progress: Float,
+    webViewContent: @Composable () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(BackgroundColor)
+    ) {
+        // Top Toolbar
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp)
+                .background(MainColorLight)
+        ) {
+            IconButton(
+                onClick = onDismiss,
+                modifier = Modifier.align(Alignment.CenterStart)
+            ) {
+                Icon(
+                    Icons.Default.Close,
+                    contentDescription = "Close",
+                    tint = MainColorDeep
+                )
+            }
+
+            Text(
+                text = title,
+                modifier = Modifier.align(Alignment.Center)
+            )
+
+            // Manual Trigger Button
+            TextButton(
+                onClick = onImport,
+                modifier = Modifier
+                    .align(Alignment.CenterEnd)
+                    .padding(end = 8.dp)
+            ) { Text(text = "가져오기", color = MainColorDeep) }
+        }
+
+        // Loading Bar (Shows during page loads OR during initial 2s delay)
+        if (isLoading) {
+            LinearProgressIndicator(
+                progress = { progress },
+                color = MainColorDeep,
+                trackColor = MainColorLight,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+
+        // WebView Area
+        // WebView and Overlay Container
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+        ) {
+            webViewContent()
+
+            if (isLoading && progress < 0.6f) {
+                LoadingScreen("페이지 연결 중...")
             }
         }
     }
@@ -322,8 +295,7 @@ fun WebViewScrapDialog(url: String, onDismiss: () -> Unit, onScrapComplete: (Lin
 
 // JS Script for metadata extraction
 private fun extractMetadata(webView: WebView) {
-    val script =
-        """
+    val script = """
         (function() {
             var ogTitle = document.querySelector('meta[property="og:title"]')?.content;
             var ogImage = document.querySelector('meta[property="og:image"]')?.content;
@@ -342,4 +314,23 @@ private fun extractMetadata(webView: WebView) {
     """.trimIndent()
 
     webView.evaluateJavascript(script, null)
+}
+
+@androidx.compose.ui.tooling.preview.Preview(showBackground = true)
+@Composable
+fun WebViewScrapDialogContentPreview() {
+    WebViewScrapDialogContent(
+        title = "직접 확인해서 추가하기",
+        onDismiss = {},
+        onImport = {},
+        isLoading = true,
+        progress = 0.5f,
+        webViewContent = {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.LightGray),
+                contentAlignment = Alignment.Center
+            ) { Text("WebView Placeholder") }
+        })
 }

--- a/app/src/main/java/com/scrap2025/scrap2025/ui/scrap/screens/AddScrapScreen.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/scrap/screens/AddScrapScreen.kt
@@ -230,7 +230,7 @@ fun AddScrapScreenContent(
                                 )
                                 Spacer(modifier = Modifier.width(8.dp))
                                 Text(
-                                    text = "정보를 못 찾겠어요. 직접 지정할까요?",
+                                    text = "정보를 못 찾겠어요. 직접 가져올까요?",
                                     style = TextStyle(
                                         fontSize = 14.sp,
                                         color = MainColorDeep,

--- a/app/src/main/java/com/scrap2025/scrap2025/ui/scrap/screens/AddScrapScreen.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/scrap/screens/AddScrapScreen.kt
@@ -134,8 +134,9 @@ fun AddScrapScreen(
     // 웹뷰 다이얼로그 표시
     if (showWebView) {
         val targetUrl =
-            url.ifBlank { "https://m.naver.com" }.let {
-                if (it.startsWith("http://") || it.startsWith("https://")) it else "https://$it"
+            url.ifBlank { "https://m.naver.com" }.let { url ->
+                if (url.startsWith("http://") || url.startsWith("https://")) url
+                else "https://$url"
             }
 
         WebViewScrapDialog(

--- a/app/src/main/java/com/scrap2025/scrap2025/ui/scrap/screens/AddScrapScreen.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/scrap/screens/AddScrapScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -23,12 +24,16 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -42,6 +47,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModelStoreOwner
 import com.scrap2025.scrap2025.model.LinkPreview
 import com.scrap2025.scrap2025.model.toScrapItem
+import com.scrap2025.scrap2025.ui.common.components.WebViewScrapDialog
 import com.scrap2025.scrap2025.ui.scrap.components.ScrapItemCardList
 import com.scrap2025.scrap2025.ui.theme.BackgroundColor
 import com.scrap2025.scrap2025.ui.theme.DarkGrayColor
@@ -72,6 +78,9 @@ fun AddScrapScreen(
     val memo by viewModel.memo.collectAsState()
     val isLoading = addScrapState is AddScrapUiState.Loading
     val globalCategoryId by mainViewModel.selectedCategoryId.collectAsState()
+
+    // 웹뷰 다이얼로그 표시 여부 상태
+    var showWebView by remember { mutableStateOf(false) }
 
     // 화면 진입 시 공유된 URL이 있는지 확인하고 소비
     LaunchedEffect(Unit) {
@@ -115,9 +124,27 @@ fun AddScrapScreen(
                 categoryId = globalCategoryId ?: 0L
             )
         },
+        onShowWebView = { showWebView = true },
         onBack = { onBack() },
         modifier = modifier
     )
+
+    // 웹뷰 다이얼로그 표시
+    if (showWebView) {
+        val targetUrl =
+            url.ifBlank { "https://m.naver.com" }.let {
+                if (it.startsWith("http://") || it.startsWith("https://")) it else "https://$it"
+            }
+
+        WebViewScrapDialog(
+            url = targetUrl,
+            onDismiss = { showWebView = false },
+            onScrapComplete = { preview ->
+                showWebView = false
+                viewModel.onManualPreviewSuccess(preview)
+            }
+        )
+    }
 }
 
 /** AddScrapScreenContent - Presentational Composable ViewModel 의존성 없이 순수한 데이터만 받아서 UI 렌더링 */
@@ -130,6 +157,7 @@ fun AddScrapScreenContent(
     onUrlChange: (String) -> Unit,
     onMemoChange: (String) -> Unit,
     onAddScrap: (url: String, memo: String, linkPreview: LinkPreview?) -> Unit,
+    onShowWebView: () -> Unit,
     onBack: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -188,12 +216,37 @@ fun AddScrapScreenContent(
                 Spacer(modifier = Modifier.height(16.dp))
 
                 // 링크 라벨
-                Text(
-                    text = "링크",
-                    style = TextStyle(fontSize = 15.sp, fontWeight = FontWeight.Medium),
-                    color = Color.Black,
-                    modifier = Modifier.padding(start = 20.dp)
-                )
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(end = 16.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = "링크",
+                        style = TextStyle(fontSize = 15.sp, fontWeight = FontWeight.Medium),
+                        color = Color.Black,
+                        modifier = Modifier.padding(start = 20.dp)
+                    )
+
+                    // 웹뷰 버튼
+                    TextButton(
+                        onClick = onShowWebView,
+                        contentPadding = PaddingValues(0.dp),
+                        modifier = Modifier.height(30.dp)
+                    ) {
+                        Text(
+                            text = "웹페이지에서 가져오기",
+                            style =
+                                TextStyle(
+                                    fontSize = 13.sp,
+                                    fontWeight = FontWeight.SemiBold
+                                ),
+                            color = MainColorDeep
+                        )
+                    }
+                }
 
                 Spacer(modifier = Modifier.height(8.dp))
 
@@ -411,6 +464,7 @@ fun AddScrapScreenContentPreview() {
             onUrlChange = {},
             onMemoChange = {},
             onAddScrap = { _, _, _ -> },
+            onShowWebView = {},
             onBack = {}
         )
     }

--- a/app/src/main/java/com/scrap2025/scrap2025/ui/scrap/screens/AddScrapScreen.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/scrap/screens/AddScrapScreen.kt
@@ -3,6 +3,7 @@ package com.scrap2025.scrap2025.ui.scrap.screens
 import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -18,6 +19,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.KeyboardArrowLeft
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -163,14 +165,6 @@ fun AddScrapScreenContent(
 ) {
     val context = LocalContext.current
 
-    // 링크 미리보기 데이터 추출
-    val linkPreview =
-        when (linkPreviewUiState) {
-            is LinkPreviewUiState.Success -> linkPreviewUiState.preview
-            else -> null
-        }
-    val isLoadingPreview = linkPreviewUiState is LinkPreviewUiState.Loading
-
     Box(modifier = Modifier.fillMaxSize()) {
         Column(modifier = modifier
             .fillMaxSize()
@@ -186,31 +180,67 @@ fun AddScrapScreenContent(
                     .weight(1f)
             ) {
 
-                // 링크 미리보기 영역
-                if (isLoadingPreview) {
-                    Spacer(modifier = Modifier.height(16.dp))
+                // 링크 미리보기 영역 (State 기반 분기 처리)
+                when (linkPreviewUiState) {
+                    is LinkPreviewUiState.Loading -> {
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Box(
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 16.dp)
+                                    .height(80.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(40.dp),
+                                color = MainColorDeep
+                            )
+                        }
+                    }
 
-                    Box(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 16.dp)
-                                .height(80.dp),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        CircularProgressIndicator(
-                            modifier = Modifier.size(40.dp),
-                            color = MainColorDeep
+                    is LinkPreviewUiState.Success -> {
+                        Spacer(modifier = Modifier.height(16.dp))
+                        ScrapItemCardList(
+                            scrapItem = linkPreviewUiState.preview.toScrapItem(),
+                            isSelectionMode = false,
+                            showCategory = false
                         )
                     }
-                } else if (linkPreview != null) {
-                    Spacer(modifier = Modifier.height(16.dp))
 
-                    ScrapItemCardList(
-                        scrapItem = linkPreview.toScrapItem(),
-                        isSelectionMode = false,
-                        showCategory = false
-                    )
+                    is LinkPreviewUiState.Error -> {
+                        // 에러 시 빈 공간 대신 "유도 UI" 노출
+                        Spacer(modifier = Modifier.height(16.dp))
+
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp)
+                                .height(80.dp) // 미리보기 카드와 비슷한 높이
+                                .background(MainColorLight, RoundedCornerShape(8.dp))
+                                .clickable { onShowWebView() }, // 클릭 시 바로 웹뷰 열기
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Icon(
+                                    imageVector = Icons.Default.Warning, // 혹은 적절한 아이콘
+                                    contentDescription = null,
+                                    tint = MainColorDeep,
+                                    modifier = Modifier.size(20.dp)
+                                )
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Text(
+                                    text = "정보를 못 찾겠어요. 직접 지정할까요?",
+                                    style = TextStyle(
+                                        fontSize = 14.sp,
+                                        color = MainColorDeep,
+//                                        textDecoration = TextDecoration.Underline
+                                    )
+                                )
+                            }
+                        }
+                    }
+                    null -> {}
                 }
 
                 Spacer(modifier = Modifier.height(16.dp))
@@ -231,21 +261,25 @@ fun AddScrapScreenContent(
                     )
 
                     // 웹뷰 버튼
-                    TextButton(
-                        onClick = onShowWebView,
-                        contentPadding = PaddingValues(0.dp),
-                        modifier = Modifier.height(30.dp)
-                    ) {
-                        Text(
-                            text = "웹페이지에서 가져오기",
-                            style =
-                                TextStyle(
-                                    fontSize = 13.sp,
-                                    fontWeight = FontWeight.SemiBold
-                                ),
-                            color = MainColorDeep
-                        )
+                    if (linkPreviewUiState is LinkPreviewUiState.Success) {
+                        TextButton(
+                            onClick = onShowWebView,
+                            contentPadding = PaddingValues(0.dp),
+                            modifier = Modifier.height(30.dp)
+                        ) {
+                            Text(
+                                text = "웹페이지에서 직접 가져오기",
+                                style =
+                                    TextStyle(
+                                        fontSize = 13.sp,
+                                        fontWeight = FontWeight.SemiBold,
+//                                    textDecoration = TextDecoration.Underline,
+                                    ),
+                                color = MainColorDeep
+                            )
+                        }
                     }
+
                 }
 
                 Spacer(modifier = Modifier.height(8.dp))
@@ -303,11 +337,10 @@ fun AddScrapScreenContent(
 
                 // 메모 입력 필드
                 Box(
-                    modifier =
-                        Modifier
-                            .fillMaxSize()
-                            .padding(horizontal = 16.dp)
-                            .padding(bottom = 16.dp)
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 16.dp)
+                        .padding(bottom = 16.dp)
                 ) {
                     TextField(
                         value = memo,
@@ -377,12 +410,20 @@ fun AddScrapScreenContent(
                 Spacer(modifier = Modifier.width(16.dp))
 
                 // 추가하기 버튼
+                val isPreviewLoading = linkPreviewUiState is LinkPreviewUiState.Loading
                 Button(
                     onClick = {
                         if (url.isBlank()) {
                             Toast.makeText(context, "링크를 입력해주세요", Toast.LENGTH_SHORT).show()
                         } else {
-                            onAddScrap(url.trim(), memo.trim(), linkPreview)
+                            // LinkPreview 추출 로직
+                            val currentLinkPreview =
+                                if (linkPreviewUiState is LinkPreviewUiState.Success) {
+                                    linkPreviewUiState.preview
+                                } else {
+                                    null
+                                }
+                            onAddScrap(url.trim(), memo.trim(), currentLinkPreview)
                         }
                     },
                     modifier = Modifier
@@ -394,9 +435,10 @@ fun AddScrapScreenContent(
                             containerColor = MainColorDeep,
                             contentColor = Color.White
                         ),
-                    enabled = !isLoading && !isLoadingPreview
+                    // 로딩 중이거나 미리보기 로딩 중이면 버튼 비활성화
+                    enabled = !isLoading && !isPreviewLoading
                 ) {
-                    if (isLoading || isLoadingPreview) {
+                    if (isLoading || isPreviewLoading) {
                         CircularProgressIndicator(
                             modifier = Modifier.size(24.dp),
                             color = Color.White
@@ -454,11 +496,11 @@ fun TopBar(
 
 @Preview(showBackground = true)
 @Composable
-fun AddScrapScreenContentPreview() {
+fun AddScrapScreenContentParsingErrorPreview() {
     Scrap2025Theme {
         AddScrapScreenContent(
             isLoading = false,
-            linkPreviewUiState = null,
+            linkPreviewUiState = LinkPreviewUiState.Error(),
             url = "",
             memo = "",
             onUrlChange = {},

--- a/app/src/main/java/com/scrap2025/scrap2025/viewmodel/AddScrapViewModel.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/viewmodel/AddScrapViewModel.kt
@@ -160,4 +160,15 @@ constructor(
         _memo.value = ""
         _linkPreviewUiState.value = null
     }
+
+    /** 웹뷰에서 직접 파싱해온 데이터를 적용합니다 */
+    fun onManualPreviewSuccess(preview: LinkPreview) {
+        android.util.Log.d("AddScrapViewModel", "onManualPreviewSuccess: $preview")
+        viewModelScope.launch {
+            // URL 필드 업데이트
+            _url.value = preview.url
+            // 미리보기 상태를 성공으로 강제 설정
+            _linkPreviewUiState.value = LinkPreviewUiState.Success(preview)
+        }
+    }
 }


### PR DESCRIPTION
기존의 자동 파싱 로직은 해당 URL의 봇에 대한 차단 정책으로 기능하지 않는 경우 발생

사용자가 직접 웹뷰를 통해 해당 링크에 방문하도록 로직 추가

1. 자동 파싱을 통해 linkpreview 생성
2. 자동 파싱 실패 시 사용자가 웹뷰를 통해 직접 접근하도록 유도
  - 자동 파싱 성공 시에도 버튼을 통해 웹뷰 접근 가능
3. 웹뷰에서 사용자가 가져오기 버튼 클릭 시 파싱 시도

봇 차단을 위한 캡챠 이미지를 사용자가 대신 수행함으로서 문제 해결

참고:
초기 개발 시 차단 우회를 위해 백그라운드에서 웹뷰를 작동시켰으나 캡쳐 이미지로 불가능하다고 판단
-> 사용자가 직접 유효한 URL까지 접근하도록 구현

close #90