### PR TITLE
feat: `인스타그램으로 연락하기` 삭제 및 UI 문구 한글화

### DIFF
--- a/app/src/main/java/com/scrap2025/scrap2025/ui/mypage/components/HelpCenterDialog.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/mypage/components/HelpCenterDialog.kt
@@ -35,15 +35,13 @@ import com.scrap2025.scrap2025.ui.theme.Scrap2025Theme
 fun HelpCenterDialog(
     onDismiss: () -> Unit,
     onContactViaEmail: () -> Unit,
-    onContactViaInstagram: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Dialog(
         onDismissRequest = onDismiss
     ) {
         Box(
-            modifier =
-            Modifier
+            modifier = modifier
                 .fillMaxWidth(0.90f)
                 .wrapContentHeight()
                 .background(color = MainColor, shape = RoundedCornerShape(20.dp))
@@ -74,14 +72,7 @@ fun HelpCenterDialog(
 
                 HelpCenterButton(
                     onClick = onContactViaEmail,
-                    text = "contact via mail\n(cs@teamscrap.co.kr)"
-                )
-
-                Spacer(modifier = Modifier.height(13.dp))
-
-                HelpCenterButton(
-                    onClick = onContactViaInstagram,
-                    text = "contact via instagram\n(@teamscrap2026)"
+                    text = "메일로 연락하기\n(cs@teamscrap.co.kr)"
                 )
 
                 Spacer(modifier = Modifier.height(13.dp))
@@ -134,8 +125,7 @@ private fun HelpCenterDialogPreview() {
     Scrap2025Theme {
         HelpCenterDialog(
             onDismiss = {},
-            onContactViaEmail = {},
-            onContactViaInstagram = {}
+            onContactViaEmail = {}
         )
     }
 }

--- a/app/src/main/java/com/scrap2025/scrap2025/ui/mypage/screens/MyPageScreen.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/mypage/screens/MyPageScreen.kt
@@ -43,10 +43,8 @@ import com.scrap2025.scrap2025.ui.mypage.components.HelpCenterDialog
 import com.scrap2025.scrap2025.ui.theme.DarkGrayColor
 import com.scrap2025.scrap2025.ui.theme.LightGrayColor
 import com.scrap2025.scrap2025.ui.theme.Scrap2025Theme
-import com.scrap2025.scrap2025.utils.INSTAGRAM_USERNAME
 import com.scrap2025.scrap2025.utils.MAIL_ADDRESS
 import com.scrap2025.scrap2025.utils.sendEmail
-import com.scrap2025.scrap2025.utils.sendInstagramDM
 import com.scrap2025.scrap2025.viewmodel.MyPageViewModel
 import com.scrap2025.scrap2025.viewmodel.MyPageViewModel.MyPageUiState
 
@@ -75,7 +73,6 @@ fun MyPageScreen(modifier: Modifier = Modifier, viewModel: MyPageViewModel = hil
                 scrapCount = state.scrapCount,
                 categoryCount = state.categoryCount,
                 onContactViaEmail = { context.sendEmail(MAIL_ADDRESS) },
-                onContactViaInstagram = { context.sendInstagramDM(INSTAGRAM_USERNAME) },
                 showHelpCenterDialog = showHelpCenterDialog,
                 showWithdrawDialog = showWithdrawDialog,
                 onHelpCenterClick = { viewModel.showHelpCenterDialog() },
@@ -108,7 +105,6 @@ fun MyPageScreenContent(
     scrapCount: Int,
     categoryCount: Int,
     onContactViaEmail: () -> Unit,
-    onContactViaInstagram: () -> Unit,
     showHelpCenterDialog: Boolean,
     showWithdrawDialog: Boolean,
     onHelpCenterClick: () -> Unit,
@@ -201,8 +197,7 @@ fun MyPageScreenContent(
     if (showHelpCenterDialog) {
         HelpCenterDialog(
             onDismiss = onHelpCenterDismiss,
-            onContactViaEmail = onContactViaEmail,
-            onContactViaInstagram = onContactViaInstagram
+            onContactViaEmail = onContactViaEmail
         )
     }
 
@@ -272,7 +267,6 @@ private fun MyPageScreenPreview() {
             scrapCount = 243,
             categoryCount = 11,
             onContactViaEmail = {},
-            onContactViaInstagram = {},
             showHelpCenterDialog = false,
             showWithdrawDialog = false,
             onHelpCenterClick = {},


### PR DESCRIPTION
- 고객센터 다이얼로그에서 인스타그램 문의 옵션 제거
- UI 문구 한글화 ("메일로 연락하기")