### PR TITLE
ci: develop PR 머지 시 연결된 이슈 자동 종료 워크플로우 수정

### DIFF
--- a/.github/workflows/auto_issue_closer.yml
+++ b/.github/workflows/auto_issue_closer.yml
@@ -38,5 +38,5 @@ jobs:
           for issue in $issues; do
             echo "Closing issue #$issue..."
             # gh cli를 사용하여 이슈 닫기 및 코멘트 남기기
-            gh issue close "$issue" --comment "Auto-closed by merge of PR #$PR_NUMBER to develop"
+            gh issue close "$issue" --repo "${{ github.repository }}" --comment "Auto-closed by merge of PR #$PR_NUMBER to develop"
           done


### PR DESCRIPTION
기존 PR #127 에 누락된 저장소 지정 명령어 추가
- `gh issue close` 명령 실행 시 `--repo "${{ github.repository }}"` 옵션을 추가하여 명시적으로 저장소 지정

close #126 