### PR TITLE
ci: Play Store 내부 테스트 트랙 자동 배포 로직 추가 (cd)

### DIFF
--- a/.github/workflows/android_ci_release.yml
+++ b/.github/workflows/android_ci_release.yml
@@ -39,3 +39,13 @@ jobs:
           name: app-prod-release
           path: app/build/outputs/bundle/prodRelease/app-prod-release.aab
           retention-days: 7
+
+      - name: Upload to Google Play
+        if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: com.scrap2025.scrap2025
+          releaseFiles: app/build/outputs/bundle/prodRelease/app-prod-release.aab
+          track: internal
+          status: completed


### PR DESCRIPTION
- `android_ci_release.yml` 내 Google Play 업로드 스텝 추가
- `workflow_dispatch` 또는 `main` 브랜치 푸시 시 자동 실행 설정
- `r0adkll/upload-google-play` 액션을 사용하여 `.aab` 파일을 내부 테스트(internal) 트랙으로 배포하도록 구성