### PR TITLE
feat: 테스트 로그인 추가

### DIFF
--- a/app/src/main/java/com/scrap2025/scrap2025/model/enums/SnsType.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/model/enums/SnsType.kt
@@ -3,5 +3,6 @@ package com.scrap2025.scrap2025.model.enums
 enum class SnsType(val value: String) {
     NAVER("naver"),
     KAKAO("kakao"),
-    GOOGLE("google")
+    GOOGLE("google"),
+    TEST("test")
 }

--- a/app/src/main/java/com/scrap2025/scrap2025/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/repository/AuthRepositoryImpl.kt
@@ -29,12 +29,12 @@ constructor(
         testRefreshToken: String
     ): Result<Unit> = try {
         tokenManager.saveTokens(testAccessToken, testRefreshToken)
-        tokenManager.saveSnsType(SnsType.KAKAO)
-        Log.d(TAG, "Tokens and SnsType saved successfully")
+        tokenManager.saveSnsType(SnsType.TEST)
+        Log.d(TAG, "TEST Tokens and SnsType saved successfully")
 
         Result.success(Unit)
     } catch (e: Exception) {
-        Log.e(TAG, "Login exception", e)
+        Log.e(TAG, "TEST Login exception", e)
         Result.failure(e)
     }
 

--- a/app/src/main/java/com/scrap2025/scrap2025/ui/login/components/LoginScreenContent.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/login/components/LoginScreenContent.kt
@@ -1,7 +1,9 @@
 package com.scrap2025.scrap2025.ui.login.components
 
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -15,27 +17,48 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableIntState
+import androidx.compose.runtime.MutableLongState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import com.scrap2025.scrap2025.BuildConfig
 import com.scrap2025.scrap2025.R
 import com.scrap2025.scrap2025.model.enums.SnsType
 import com.scrap2025.scrap2025.ui.theme.GrayColor
 import com.scrap2025.scrap2025.ui.theme.LightGrayColor
 import com.scrap2025.scrap2025.ui.theme.MainColor
+import com.scrap2025.scrap2025.ui.theme.MainColorDeep
 import com.scrap2025.scrap2025.ui.theme.Scrap2025Theme
+
+private const val TEST_PASSWORD = "scrap2025-test-login"
 
 private val MainTextStyle =
     TextStyle(fontSize = 22.sp, fontWeight = FontWeight.SemiBold, lineHeight = 28.sp)
@@ -47,6 +70,10 @@ fun LoginScreenContent(
     onTestLogin: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val clickCountState = remember { mutableIntStateOf(0) }
+    val lastClickTimeState = remember { mutableLongStateOf(0L) }
+    var showSecretDialog by remember { mutableStateOf(false) }
+
     Column(
         modifier =
         modifier
@@ -92,13 +119,23 @@ fun LoginScreenContent(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Box(
-                modifier =
-                Modifier
+                modifier = Modifier
                     .border(1.5.dp, LightGrayColor, RoundedCornerShape(30.dp))
                     .background(
                         color = MainColor,
                         shape = RoundedCornerShape(30.dp)
-                    ).padding(horizontal = 16.dp, vertical = 8.dp),
+                    ).padding(horizontal = 16.dp, vertical = 8.dp)
+                    .pointerInput(Unit) {
+                        detectTapGestures(
+                            onTap = {
+                                handleSecretTap(
+                                    clickCountState = clickCountState,
+                                    lastClickTimeState = lastClickTimeState,
+                                    goToSecretDialog = { showSecretDialog = true }
+                                )
+                            }
+                        )
+                    },
                 contentAlignment = Alignment.Center
             ) {
                 Text(
@@ -116,6 +153,16 @@ fun LoginScreenContent(
             }
             Spacer(modifier = Modifier.height(20.dp))
         }
+    }
+
+    if (showSecretDialog) {
+        SecretLoginDialog(
+            onDismiss = { showSecretDialog = false },
+            onConfirm = {
+                showSecretDialog = false
+                onTestLogin() // 기존 onTestLogin 실행
+            }
+        )
     }
 }
 
@@ -175,8 +222,112 @@ private fun NaverLoginButton(onClick: () -> Unit) {
     }
 }
 
+private fun handleSecretTap(
+    clickCountState: MutableIntState,
+    lastClickTimeState: MutableLongState,
+    goToSecretDialog: () -> Unit
+) {
+    val currentTime = System.currentTimeMillis()
+    val lastTime = lastClickTimeState.longValue
+    val currentCount = clickCountState.intValue
+
+    val newCount = if (currentTime - lastTime < 1000) {
+        currentCount + 1
+    } else {
+        1
+    }
+    // 상태 업데이트
+    clickCountState.intValue = newCount
+    lastClickTimeState.longValue = currentTime
+
+    if (newCount >= 5) {
+        goToSecretDialog()
+        clickCountState.intValue = 0
+    }
+}
+
+@Composable
+private fun SecretLoginDialog(onDismiss: () -> Unit, onConfirm: () -> Unit) {
+    val context = LocalContext.current
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false) // 전체 화면 사용
+    ) {
+        var password by remember { mutableStateOf("") }
+
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = Color.White
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(24.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    val handleLoginCheck = {
+                        if (password == TEST_PASSWORD) {
+                            onConfirm()
+                        } else {
+                            Toast.makeText(context, "wrong password", Toast.LENGTH_SHORT).show()
+                        }
+                    }
+
+                    Text(
+                        text = "FOR_TEST_LOGIN",
+                        style = TextStyle(fontSize = 20.sp, fontWeight = FontWeight.Bold),
+                        modifier = Modifier.padding(bottom = 32.dp)
+                    )
+
+                    OutlinedTextField(
+                        value = password,
+                        onValueChange = { password = it },
+                        placeholder = { Text("enter password") },
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                        keyboardActions = KeyboardActions(onDone = { handleLoginCheck() }),
+                        shape = RoundedCornerShape(16.dp),
+                        modifier = Modifier.fillMaxWidth()
+                    )
+
+                    Spacer(modifier = Modifier.height(24.dp))
+
+                    Button(
+                        onClick = handleLoginCheck,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(56.dp),
+                        colors = ButtonDefaults.buttonColors(containerColor = MainColorDeep),
+                        shape = RoundedCornerShape(16.dp)
+                    ) {
+                        Text("confirm", fontSize = 16.sp)
+                    }
+                    TextButton(
+                        onClick = onDismiss,
+                        modifier = Modifier.padding(top = 16.dp)
+                    ) {
+                        Text("dismiss", color = GrayColor)
+                    }
+                }
+            }
+        }
+    }
+}
+
 @Preview(showBackground = true)
 @Composable
 private fun LoginScreenPreview() {
     Scrap2025Theme { LoginScreenContent(onLoginClick = {}, onTestLogin = {}) }
+}
+
+@Preview
+@Composable
+private fun SecretDialogPreview() {
+    SecretLoginDialog(onDismiss = {}, onConfirm = {})
 }

--- a/app/src/main/java/com/scrap2025/scrap2025/ui/mypage/screens/MyPageScreen.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/mypage/screens/MyPageScreen.kt
@@ -60,7 +60,6 @@ fun MyPageScreen(modifier: Modifier = Modifier, viewModel: MyPageViewModel = hil
         MyPageUiState.Loading -> {
             LoadingScreen()
         }
-
         is MyPageUiState.Success -> {
             val greetingText =
                 remember(state.myPageInfo.memberInfo.name) {
@@ -115,12 +114,7 @@ fun MyPageScreenContent(
     onWithdrawDismiss: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Column(
-        modifier =
-        modifier
-            .fillMaxSize()
-            .background(Color.White)
-    ) {
+    Column(modifier = modifier.fillMaxSize().background(Color.White)) {
         Spacer(modifier = Modifier.height(20.dp))
 
         // Title
@@ -134,23 +128,14 @@ fun MyPageScreenContent(
 
         Spacer(modifier = Modifier.height(40.dp))
 
-        Row(
-            Modifier.padding(horizontal = 20.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(
-                text = greetingText,
-                fontSize = 20.sp
-            )
+        Row(Modifier.padding(horizontal = 20.dp), verticalAlignment = Alignment.CenterVertically) {
+            Text(text = greetingText, fontSize = 20.sp)
             Spacer(Modifier.width(8.dp))
             Icon(
                 painter = painterResource(snsType.getIconRes()),
                 contentDescription = "SNS Icon",
                 tint = Color.Unspecified,
-                modifier =
-                Modifier
-                    .padding(top = 1.dp)
-                    .size(20.dp)
+                modifier = Modifier.padding(top = 1.dp).size(20.dp)
             )
         }
 
@@ -158,10 +143,7 @@ fun MyPageScreenContent(
 
         // Stats Row
         Row(
-            modifier =
-            Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 20.dp),
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp),
             horizontalArrangement = Arrangement.Center
         ) {
             // Scrap Stat
@@ -195,10 +177,7 @@ fun MyPageScreenContent(
 
     // 3. 다이얼로그 표시 로직
     if (showHelpCenterDialog) {
-        HelpCenterDialog(
-            onDismiss = onHelpCenterDismiss,
-            onContactViaEmail = onContactViaEmail
-        )
+        HelpCenterDialog(onDismiss = onHelpCenterDismiss, onContactViaEmail = onContactViaEmail)
     }
 
     if (showWithdrawDialog) {
@@ -228,12 +207,7 @@ fun StatItem(icon: Painter, count: String, label: String) {
 
 @Composable
 fun MenuItem(text: String, onClick: () -> Unit) {
-    Box(
-        modifier =
-        Modifier
-            .fillMaxWidth()
-            .clickable { onClick() }
-    ) {
+    Box(modifier = Modifier.fillMaxWidth().clickable { onClick() }) {
         Text(
             text = text,
             fontSize = 16.sp,
@@ -245,9 +219,7 @@ fun MenuItem(text: String, onClick: () -> Unit) {
 
 private fun getGreetingText(userName: String): AnnotatedString = buildAnnotatedString {
     append("안녕하세요 ")
-    withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
-        append(userName)
-    }
+    withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) { append(userName) }
     append(" 님!")
 }
 
@@ -255,6 +227,7 @@ private fun SnsType.getIconRes(): Int = when (this) {
     SnsType.NAVER -> R.drawable.ic_naver_logo
     SnsType.KAKAO -> R.drawable.ic_kakao_logo
     SnsType.GOOGLE -> 0 // 미구현 // R.drawable.ic_google_logo
+    SnsType.TEST -> R.drawable.ic_scrap
 }
 
 @Preview(showBackground = true)

--- a/app/src/main/java/com/scrap2025/scrap2025/ui/mypage/screens/MyPageScreen.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/mypage/screens/MyPageScreen.kt
@@ -1,5 +1,6 @@
 package com.scrap2025.scrap2025.ui.mypage.screens
 
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -44,6 +45,7 @@ import com.scrap2025.scrap2025.ui.theme.DarkGrayColor
 import com.scrap2025.scrap2025.ui.theme.LightGrayColor
 import com.scrap2025.scrap2025.ui.theme.Scrap2025Theme
 import com.scrap2025.scrap2025.utils.MAIL_ADDRESS
+import com.scrap2025.scrap2025.utils.ObserveAsEvents
 import com.scrap2025.scrap2025.utils.sendEmail
 import com.scrap2025.scrap2025.viewmodel.MyPageViewModel
 import com.scrap2025.scrap2025.viewmodel.MyPageViewModel.MyPageUiState
@@ -55,6 +57,14 @@ fun MyPageScreen(modifier: Modifier = Modifier, viewModel: MyPageViewModel = hil
     val showWithdrawDialog by viewModel.showWithdrawDialog.collectAsState()
     val showHelpCenterDialog by viewModel.showHelpCenterDialog.collectAsState()
     val uiState by viewModel.uiState.collectAsState()
+
+    ObserveAsEvents(viewModel.event) { event ->
+        when (event) {
+            is MyPageViewModel.MyPageUiEvent.ShowToast -> {
+                Toast.makeText(context, event.message, Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
 
     when (val state = uiState) {
         MyPageUiState.Loading -> {

--- a/app/src/main/java/com/scrap2025/scrap2025/utils/ObserveAsEvents.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/utils/ObserveAsEvents.kt
@@ -1,0 +1,16 @@
+package com.scrap2025.scrap2025.utils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.flow.Flow
+
+@Composable
+fun <T> ObserveAsEvents(flow: Flow<T>, onEvent: (T) -> Unit) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+    LaunchedEffect(flow, lifecycleOwner) {
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) { flow.collect(onEvent) }
+    }
+}

--- a/app/src/main/java/com/scrap2025/scrap2025/viewmodel/MyPageViewModel.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/viewmodel/MyPageViewModel.kt
@@ -13,9 +13,12 @@ import com.scrap2025.scrap2025.repository.MyPageRepository
 import com.scrap2025.scrap2025.repository.ScrapRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.merge
@@ -44,6 +47,13 @@ constructor(
             val snsType: SnsType
         ) : MyPageUiState
     }
+
+    sealed interface MyPageUiEvent {
+        data class ShowToast(val message: String) : MyPageUiEvent
+    }
+
+    private val _event = MutableSharedFlow<MyPageUiEvent>()
+    val event: SharedFlow<MyPageUiEvent> = _event.asSharedFlow()
 
     private val _showWithdrawDialog = MutableStateFlow(false)
     val showWithdrawDialog: StateFlow<Boolean> = _showWithdrawDialog.asStateFlow()
@@ -176,6 +186,7 @@ constructor(
         callback: suspend (SocialLoginProvider) -> Result<Unit>
     ): Result<Unit> {
         if (snsType == SnsType.TEST) {
+            _event.emit(MyPageUiEvent.ShowToast("withdrawal is not supported for test logins"))
             return Result.failure(Exception("테스트 로그인은 회원탈퇴 기능이 지원되지 않습니다."))
         }
 

--- a/app/src/main/java/com/scrap2025/scrap2025/viewmodel/MyPageViewModel.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/viewmodel/MyPageViewModel.kt
@@ -149,6 +149,10 @@ constructor(
         snsType: SnsType,
         callback: suspend (SocialLoginProvider) -> Result<Unit>
     ): Result<Unit> {
+        if (snsType == SnsType.TEST) {
+            return Result.success(Unit)
+        }
+
         val provider =
             socialLoginProviders[snsType]
                 ?: return Result.failure(Exception("소셜 로그인 프로바이더를 찾을 수 없습니다."))
@@ -171,6 +175,10 @@ constructor(
         snsType: SnsType,
         callback: suspend (SocialLoginProvider) -> Result<Unit>
     ): Result<Unit> {
+        if (snsType == SnsType.TEST) {
+            return Result.failure(Exception("테스트 로그인은 회원탈퇴 기능이 지원되지 않습니다."))
+        }
+
         val provider =
             socialLoginProviders[snsType]
                 ?: return Result.failure(Exception("소셜 로그인 프로바이더를 찾을 수 없습니다."))


### PR DESCRIPTION
- `3초만에 시작하기 ✨` 버튼을 5번 클릭 시 테스트 로그인을 위한 다이얼로그 출력
- 비밀번호 입력 시 테스트 로그인
- 회원탈퇴 제한 및 안내 토스트 메세지 출력