### PR TITLE
fix(ci): bypass missing local.properties keys on CI

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -67,6 +67,10 @@ android {
     fun getSecret(key: String): String {
         val value = properties.getProperty(key)
         if (value.isNullOrEmpty()) {
+            // GitHub Actions 등 CI 환경에서는 실제 Secret 없이도 린트/테스트 빌드가 가능하도록 플레이스홀더를 제공
+            if (System.getenv("CI") == "true") {
+                return "CI_PLACEHOLDER"
+            }
             throw GradleException("Key '$key' is missing or empty in local.properties")
         }
         return value

--- a/app/src/main/java/com/scrap2025/scrap2025/ui/mypage/components/HelpCenterDialog.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/mypage/components/HelpCenterDialog.kt
@@ -35,6 +35,7 @@ import com.scrap2025.scrap2025.ui.theme.Scrap2025Theme
 fun HelpCenterDialog(
     onDismiss: () -> Unit,
     onContactViaEmail: () -> Unit,
+    onContactViaInstagram: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Dialog(
@@ -73,6 +74,13 @@ fun HelpCenterDialog(
                 HelpCenterButton(
                     onClick = onContactViaEmail,
                     text = "메일로 연락하기\n(cs@teamscrap.co.kr)"
+                )
+
+                Spacer(modifier = Modifier.height(13.dp))
+
+                HelpCenterButton(
+                    onClick = onContactViaInstagram,
+                    text = "인스타그램으로 연락하기\n(@teamscrap2026)"
                 )
 
                 Spacer(modifier = Modifier.height(13.dp))
@@ -125,7 +133,8 @@ private fun HelpCenterDialogPreview() {
     Scrap2025Theme {
         HelpCenterDialog(
             onDismiss = {},
-            onContactViaEmail = {}
+            onContactViaEmail = {},
+            onContactViaInstagram = {}
         )
     }
 }

--- a/app/src/main/java/com/scrap2025/scrap2025/ui/mypage/screens/MyPageScreen.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/mypage/screens/MyPageScreen.kt
@@ -44,9 +44,11 @@ import com.scrap2025.scrap2025.ui.mypage.components.HelpCenterDialog
 import com.scrap2025.scrap2025.ui.theme.DarkGrayColor
 import com.scrap2025.scrap2025.ui.theme.LightGrayColor
 import com.scrap2025.scrap2025.ui.theme.Scrap2025Theme
+import com.scrap2025.scrap2025.utils.INSTAGRAM_USERNAME
 import com.scrap2025.scrap2025.utils.MAIL_ADDRESS
 import com.scrap2025.scrap2025.utils.ObserveAsEvents
 import com.scrap2025.scrap2025.utils.sendEmail
+import com.scrap2025.scrap2025.utils.sendInstagramDM
 import com.scrap2025.scrap2025.viewmodel.MyPageViewModel
 import com.scrap2025.scrap2025.viewmodel.MyPageViewModel.MyPageUiState
 
@@ -82,6 +84,7 @@ fun MyPageScreen(modifier: Modifier = Modifier, viewModel: MyPageViewModel = hil
                 scrapCount = state.scrapCount,
                 categoryCount = state.categoryCount,
                 onContactViaEmail = { context.sendEmail(MAIL_ADDRESS) },
+                onContactViaInstagram = { context.sendInstagramDM(INSTAGRAM_USERNAME) },
                 showHelpCenterDialog = showHelpCenterDialog,
                 showWithdrawDialog = showWithdrawDialog,
                 onHelpCenterClick = { viewModel.showHelpCenterDialog() },
@@ -114,6 +117,7 @@ fun MyPageScreenContent(
     scrapCount: Int,
     categoryCount: Int,
     onContactViaEmail: () -> Unit,
+    onContactViaInstagram: () -> Unit,
     showHelpCenterDialog: Boolean,
     showWithdrawDialog: Boolean,
     onHelpCenterClick: () -> Unit,
@@ -187,7 +191,11 @@ fun MyPageScreenContent(
 
     // 3. 다이얼로그 표시 로직
     if (showHelpCenterDialog) {
-        HelpCenterDialog(onDismiss = onHelpCenterDismiss, onContactViaEmail = onContactViaEmail)
+        HelpCenterDialog(
+            onDismiss = onHelpCenterDismiss,
+            onContactViaEmail = onContactViaEmail,
+            onContactViaInstagram = onContactViaInstagram
+        )
     }
 
     if (showWithdrawDialog) {
@@ -250,6 +258,7 @@ private fun MyPageScreenPreview() {
             scrapCount = 243,
             categoryCount = 11,
             onContactViaEmail = {},
+            onContactViaInstagram = {},
             showHelpCenterDialog = false,
             showWithdrawDialog = false,
             onHelpCenterClick = {},

--- a/app/src/main/java/com/scrap2025/scrap2025/ui/scrap/components/ScrapItemCardGrid.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/scrap/components/ScrapItemCardGrid.kt
@@ -2,6 +2,7 @@ package com.scrap2025.scrap2025.ui.scrap.components
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -25,6 +26,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -40,6 +42,7 @@ import com.scrap2025.scrap2025.ui.theme.FavoriteColor
 import com.scrap2025.scrap2025.ui.theme.GrayColor
 import com.scrap2025.scrap2025.ui.theme.LightGrayColor
 import com.scrap2025.scrap2025.ui.theme.Scrap2025Theme
+import com.scrap2025.scrap2025.utils.openUrl
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
@@ -55,6 +58,7 @@ fun ScrapItemCardGrid(
     onSelectionToggle: () -> Unit = {},
     onClick: () -> Unit = {}
 ) {
+    val context = LocalContext.current
     Card(
         modifier =
         modifier.size(width = 164.dp, height = 190.dp)
@@ -90,7 +94,14 @@ fun ScrapItemCardGrid(
                                 topStart = 15.dp,
                                 topEnd = 15.dp
                             )
-                        ),
+                        )
+                        .clickable {
+                            if (isSelectionMode) {
+                                onSelectionToggle()
+                            } else {
+                                context.openUrl(scrapItem.url)
+                            }
+                        },
                     contentAlignment = Alignment.Center
                 ) {
                     ScrapImage(

--- a/app/src/main/java/com/scrap2025/scrap2025/ui/scrap/components/ScrapItemCardList.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/scrap/components/ScrapItemCardList.kt
@@ -3,6 +3,7 @@ package com.scrap2025.scrap2025.ui.scrap.components
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -26,6 +27,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -40,6 +42,7 @@ import com.scrap2025.scrap2025.ui.theme.FavoriteColor
 import com.scrap2025.scrap2025.ui.theme.GrayColor
 import com.scrap2025.scrap2025.ui.theme.LightGrayColor
 import com.scrap2025.scrap2025.ui.theme.Scrap2025Theme
+import com.scrap2025.scrap2025.utils.openUrl
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
@@ -56,6 +59,7 @@ fun ScrapItemCardList(
     onSelectionToggle: () -> Unit = {},
     onClick: () -> Unit = {}
 ) {
+    val context = LocalContext.current
     Card(
         modifier =
         modifier
@@ -95,7 +99,14 @@ fun ScrapItemCardList(
                             width = 1.dp,
                             color = LightGrayColor,
                             shape = RoundedCornerShape(4.dp)
-                        ),
+                        )
+                        .clickable {
+                            if (isSelectionMode) {
+                                onSelectionToggle()
+                            } else {
+                                context.openUrl(scrapItem.url)
+                            }
+                        },
                     contentAlignment = Alignment.Center
                 ) {
                     ScrapImage(

--- a/app/src/main/java/com/scrap2025/scrap2025/ui/scrap/screens/ScrapDetailScreen.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/scrap/screens/ScrapDetailScreen.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.content.res.Configuration
 import android.widget.Toast
 import androidx.compose.foundation.background
+import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -377,12 +378,14 @@ fun DetailTopBar(title: String, onBackClick: () -> Unit, modifier: Modifier = Mo
 
         // 제목
         Text(
-            modifier = Modifier.padding(end = 20.dp),
+            modifier = Modifier
+                .weight(1f)
+                .padding(end = 20.dp)
+                .basicMarquee(),
             text = title,
             style = TextStyle(fontSize = 18.sp, fontWeight = FontWeight.SemiBold),
             color = Color.Black,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis
+            maxLines = 1
         )
     }
 }


### PR DESCRIPTION
Bypasses missing NAVER_CLIENT_ID and other secrets on CI environments (e.g. forked PRs) by returning a placeholder instead of throwing a GradleException.