### PR TITLE
fix: 화면 진입 시 확인 버튼 초록색 활성화 UX 개선

### DIFF
--- a/app/src/main/java/com/scrap2025/scrap2025/ui/category/screens/AddCategoryScreen.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/category/screens/AddCategoryScreen.kt
@@ -105,6 +105,7 @@ fun AddCategoryScreenContent(
                 confirmText = "추가하기",
                 onCancel = onBack,
                 onConfirm = onAddCategory,
+                isEnabled = categoryTitleInput.isNotBlank(),
                 isLoading = addCategoryUiState is AddCategoryUiState.Loading
             )
         }

--- a/app/src/main/java/com/scrap2025/scrap2025/ui/category/screens/CategorySelectionScreen.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/category/screens/CategorySelectionScreen.kt
@@ -156,7 +156,12 @@ fun CategorySelectionScreenContent(
     Scaffold(
         topBar = { TopBarWithBack(title = title, onBack = onBack) },
         bottomBar = {
-            TwoButtons(confirmText = confirmText, onCancel = onBack, onConfirm = onConfirm)
+            TwoButtons(
+                confirmText = confirmText,
+                onCancel = onBack,
+                onConfirm = onConfirm,
+                isEnabled = if (isMultiSelect) true else selectedCategoryId != 0L
+            )
         },
         floatingActionButton = {
             FloatingActionButton(

--- a/app/src/main/java/com/scrap2025/scrap2025/ui/common/buttons/TwoButtons.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/common/buttons/TwoButtons.kt
@@ -27,6 +27,7 @@ fun TwoButtons(
     confirmText: String,
     onCancel: () -> Unit,
     onConfirm: () -> Unit,
+    isEnabled: Boolean,
     modifier: Modifier = Modifier,
     isLoading: Boolean = false
 ) {
@@ -57,7 +58,7 @@ fun TwoButtons(
         // 추가하기 버튼
         Button(
             onClick = { onConfirm() },
-            enabled = !isLoading,
+            enabled = !isLoading && isEnabled,
             modifier =
             Modifier
                 .weight(1f)


### PR DESCRIPTION
## Summary
- 카테고리명/카테고리 선택이 비어있는 초기 상태에서도 확인 버튼이 활성(초록색)으로 보이던 UX 문제 수정
- `TwoButtons`에 `isEnabled: Boolean` 필수 파라미터 추가 (기본값 없음 — 호출부가 명시적으로 결정하도록 강제)
- `AddCategoryScreen`: 카테고리명 미입력 시 버튼 비활성화 (`categoryTitleInput.isNotBlank()`)
- `CategorySelectionScreen`: 카테고리 미선택(`selectedCategoryId == 0L`) 시 버튼 비활성화 (SEARCH 모드는 항상 활성)

## Test plan
- [x] AddCategoryScreen 진입 → 버튼 비활성(회색) 확인
- [x] 텍스트 입력 → 버튼 활성(초록) 전환 확인
- [x] 텍스트 전체 삭제 → 다시 비활성 확인
- [x] 로딩 중 → 스피너 표시 + 비활성 유지 확인
- [x] SEARCH에서 카테고리 선택 시 → 항상 활성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)