### PR TITLE
fix: 회원탈퇴 버튼 클릭 시 로딩 피드백 없는 문제 수정

### DIFF
--- a/app/src/main/java/com/scrap2025/scrap2025/ui/common/dialogs/CommonDeleteDialog.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/common/dialogs/CommonDeleteDialog.kt
@@ -17,6 +17,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -45,6 +46,7 @@ import com.scrap2025.scrap2025.ui.theme.WarningColor
  * @param confirmText 삭제/확인 버튼 텍스트 (필수)
  * @param onDismiss 취소 버튼 클릭 시 호출
  * @param onConfirm 삭제/확인 버튼 클릭 시 호출
+ * @param isLoading true일 때 확인 버튼을 로딩 인디케이터로 교체하고 모든 버튼을 비활성화
  */
 @Composable
 fun CommonDeleteDialog(
@@ -53,11 +55,15 @@ fun CommonDeleteDialog(
     onDismiss: () -> Unit,
     onConfirm: () -> Unit,
     modifier: Modifier = Modifier,
-    description: String? = null
+    description: String? = null,
+    isLoading: Boolean = false
 ) {
     Dialog(
-        onDismissRequest = onDismiss,
-        properties = DialogProperties(dismissOnBackPress = true, dismissOnClickOutside = true)
+        onDismissRequest = { if (!isLoading) onDismiss() },
+        properties = DialogProperties(
+            dismissOnBackPress = !isLoading,
+            dismissOnClickOutside = !isLoading
+        )
     ) {
         Box(
             modifier =
@@ -121,6 +127,7 @@ fun CommonDeleteDialog(
                     // 취소 버튼
                     Button(
                         onClick = onDismiss,
+                        enabled = !isLoading,
                         modifier =
                         Modifier
                             .weight(1f)
@@ -147,6 +154,7 @@ fun CommonDeleteDialog(
                     // 삭제/확인 버튼
                     Button(
                         onClick = onConfirm,
+                        enabled = !isLoading,
                         modifier =
                         Modifier
                             .weight(1f)
@@ -158,14 +166,21 @@ fun CommonDeleteDialog(
                             contentColor = Color.White
                         )
                     ) {
-                        Text(
-                            text = confirmText,
-                            style =
-                            TextStyle(
-                                fontSize = 17.sp,
-                                fontWeight = FontWeight.SemiBold
+                        if (isLoading) {
+                            CircularProgressIndicator(
+                                color = Color.White,
+                                modifier = Modifier.size(24.dp)
                             )
-                        )
+                        } else {
+                            Text(
+                                text = confirmText,
+                                style =
+                                TextStyle(
+                                    fontSize = 17.sp,
+                                    fontWeight = FontWeight.SemiBold
+                                )
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/scrap2025/scrap2025/ui/mypage/screens/MyPageScreen.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/mypage/screens/MyPageScreen.kt
@@ -57,6 +57,7 @@ import com.scrap2025.scrap2025.viewmodel.MyPageViewModel.MyPageUiState
 fun MyPageScreen(modifier: Modifier = Modifier, viewModel: MyPageViewModel = hiltViewModel()) {
     val context = LocalContext.current
     val showWithdrawDialog by viewModel.showWithdrawDialog.collectAsState()
+    val isWithdrawing by viewModel.isWithdrawing.collectAsState()
     val showHelpCenterDialog by viewModel.showHelpCenterDialog.collectAsState()
     val uiState by viewModel.uiState.collectAsState()
 
@@ -87,6 +88,7 @@ fun MyPageScreen(modifier: Modifier = Modifier, viewModel: MyPageViewModel = hil
                 onContactViaInstagram = { context.sendInstagramDM(INSTAGRAM_USERNAME) },
                 showHelpCenterDialog = showHelpCenterDialog,
                 showWithdrawDialog = showWithdrawDialog,
+                isWithdrawing = isWithdrawing,
                 onHelpCenterClick = { viewModel.showHelpCenterDialog() },
                 onHelpCenterDismiss = { viewModel.dismissHelpCenterDialog() },
                 onLogout = { snsType ->
@@ -120,6 +122,7 @@ fun MyPageScreenContent(
     onContactViaInstagram: () -> Unit,
     showHelpCenterDialog: Boolean,
     showWithdrawDialog: Boolean,
+    isWithdrawing: Boolean,
     onHelpCenterClick: () -> Unit,
     onHelpCenterDismiss: () -> Unit,
     onLogout: (SnsType) -> Unit,
@@ -203,7 +206,8 @@ fun MyPageScreenContent(
             title = "정말 회원탈퇴 하시겠습니까?",
             confirmText = "회원탈퇴",
             onConfirm = { onWithdrawConfirm(snsType) },
-            onDismiss = onWithdrawDismiss
+            onDismiss = onWithdrawDismiss,
+            isLoading = isWithdrawing
         )
     }
 }
@@ -261,6 +265,7 @@ private fun MyPageScreenPreview() {
             onContactViaInstagram = {},
             showHelpCenterDialog = false,
             showWithdrawDialog = false,
+            isWithdrawing = false,
             onHelpCenterClick = {},
             onHelpCenterDismiss = {},
             onLogout = {},

--- a/app/src/main/java/com/scrap2025/scrap2025/viewmodel/MyPageViewModel.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/viewmodel/MyPageViewModel.kt
@@ -58,6 +58,9 @@ constructor(
     private val _showWithdrawDialog = MutableStateFlow(false)
     val showWithdrawDialog: StateFlow<Boolean> = _showWithdrawDialog.asStateFlow()
 
+    private val _isWithdrawing = MutableStateFlow(false)
+    val isWithdrawing: StateFlow<Boolean> = _isWithdrawing.asStateFlow()
+
     private val _showHelpCenterDialog = MutableStateFlow(false)
     val showHelpCenterDialog: StateFlow<Boolean> = _showHelpCenterDialog.asStateFlow()
 
@@ -140,6 +143,7 @@ constructor(
         socialWithdrawCallback: suspend (SocialLoginProvider) -> Result<Unit>
     ) {
         viewModelScope.launch {
+            _isWithdrawing.value = true
             // 소셜 연동 해제 (회원 탈퇴)
             val socialResult = requestSocialWithdraw(snsType, socialWithdrawCallback)
 
@@ -151,6 +155,7 @@ constructor(
                 }.onFailure { exception ->
                     val errorMsg = "소셜 연동해제 실패: ${exception.message}"
                     Log.e(TAG, errorMsg)
+                    _isWithdrawing.value = false
                 }
         }
     }

--- a/app/src/main/java/com/scrap2025/scrap2025/viewmodel/MyPageViewModel.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/viewmodel/MyPageViewModel.kt
@@ -144,19 +144,22 @@ constructor(
     ) {
         viewModelScope.launch {
             _isWithdrawing.value = true
-            // 소셜 연동 해제 (회원 탈퇴)
-            val socialResult = requestSocialWithdraw(snsType, socialWithdrawCallback)
+            try {
+                // 소셜 연동 해제 (회원 탈퇴)
+                val socialResult = requestSocialWithdraw(snsType, socialWithdrawCallback)
 
-            socialResult
-                .onSuccess {
-                    Log.d(TAG, "소셜 연동해제 성공")
-                    // 서버 회원 탈퇴
-                    requestServerWithdraw()
-                }.onFailure { exception ->
-                    val errorMsg = "소셜 연동해제 실패: ${exception.message}"
-                    Log.e(TAG, errorMsg)
-                    _isWithdrawing.value = false
-                }
+                socialResult
+                    .onSuccess {
+                        Log.d(TAG, "소셜 연동해제 성공")
+                        // 서버 회원 탈퇴
+                        requestServerWithdraw()
+                    }.onFailure { exception ->
+                        val errorMsg = "소셜 연동해제 실패: ${exception.message}"
+                        Log.e(TAG, errorMsg)
+                    }
+            } finally {
+                _isWithdrawing.value = false
+            }
         }
     }
 


### PR DESCRIPTION
Closes #164

## Summary
- 회원탈퇴 확인 다이얼로그(`CommonDeleteDialog`)에 `isLoading` 파라미터를 추가하여, 탈퇴 처리 중 버튼이 비활성화되고 확인 버튼이 `CircularProgressIndicator`로 바뀌도록 함
- `MyPageViewModel`에 `isWithdrawing` 상태를 추가해 탈퇴 처리 중임을 추적
- `try-finally`로 감싸 성공/실패/예외 모든 경로에서 `isWithdrawing`이 다시 `false`로 초기화되도록 보장 (탈퇴 성공 후 로딩 상태가 영원히 true로 남는 버그 수정)

## Why
회원탈퇴 버튼을 누른 후 API 호출이 진행되는 동안 사용자에게 아무런 시각적 피드백이 없어, 중복 클릭이 가능하고 처리 중임을 알 수 없는 문제가 있었음.

## Test plan
- [ ] 회원탈퇴 다이얼로그에서 확인 버튼을 누르면 즉시 버튼이 비활성화되고 로딩 인디케이터가 표시되는지 확인
- [ ] 로딩 중에는 뒤로가기/외부 터치로 다이얼로그가 닫히지 않는지 확인
- [ ] 소셜 연동 해제 실패 시 로딩 상태가 풀리고 다시 클릭 가능한지 확인
- [ ] 정상 탈퇴 성공 시 (화면 전환 전까지) 로딩 상태가 풀리는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
