### PR TITLE
fix: 스크랩 상세 → 목록 복귀 시 하단 바 이중 표시 수정

### DIFF
--- a/app/src/main/java/com/scrap2025/scrap2025/ui/scrap/screens/ScrapDetailScreen.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/scrap/screens/ScrapDetailScreen.kt
@@ -30,6 +30,8 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -48,6 +50,7 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import com.gigamole.composeshadowsplus.common.ShadowsPlusType
@@ -66,6 +69,7 @@ import com.scrap2025.scrap2025.ui.theme.Scrap2025Theme
 import com.scrap2025.scrap2025.ui.theme.WarningColor
 import com.scrap2025.scrap2025.utils.copyToClipboard
 import com.scrap2025.scrap2025.utils.openUrl
+import com.scrap2025.scrap2025.viewmodel.MainViewModel
 import com.scrap2025.scrap2025.viewmodel.ScrapDetailUiState
 import com.scrap2025.scrap2025.viewmodel.ScrapDetailViewModel
 import java.time.LocalDateTime
@@ -76,11 +80,18 @@ fun ScrapDetailScreen(
     onEditMemo: (String) -> Unit,
     onMove: () -> Unit,
     modifier: Modifier = Modifier,
-    viewModel: ScrapDetailViewModel = hiltViewModel()
+    viewModel: ScrapDetailViewModel = hiltViewModel(),
+    mainViewModel: MainViewModel =
+        hiltViewModel(viewModelStoreOwner = LocalContext.current as ViewModelStoreOwner)
 ) {
     val context = LocalContext.current
 
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    // 화면 이탈(컴포지션 해제) 시 바 초기화 — Loading/Error 상태에서도 항상 정리
+    DisposableEffect(Unit) {
+        onDispose { mainViewModel.setBottomBar(null) }
+    }
 
     when (val state = uiState) {
         is ScrapDetailUiState.Loading -> LoadingScreen()
@@ -96,6 +107,30 @@ fun ScrapDetailScreen(
             val scrapItem = state.scrapItem
             val isDeleteDialogVisible by
                 viewModel.isDeleteDialogVisible.collectAsStateWithLifecycle()
+
+            // isFavorite 변경 시에도 바가 최신 상태를 반영하도록 키에 포함
+            LaunchedEffect(scrapItem.isFavorite) {
+                mainViewModel.setBottomBar {
+                    DetailBottomBar(
+                        isFavorite = scrapItem.isFavorite,
+                        onDelete = { viewModel.showDeleteDialog() },
+                        initialMemo = scrapItem.memo,
+                        onEditMemo = onEditMemo,
+                        onShare = { shareScrap(context, scrapItem) },
+                        onMove = onMove,
+                        onToggleFavorite = {
+                            viewModel.toggleFavorite(
+                                onSuccess = {},
+                                onFailure = {
+                                    Toast
+                                        .makeText(context, "즐겨찾기 실패", Toast.LENGTH_SHORT)
+                                        .show()
+                                }
+                            )
+                        }
+                    )
+                }
+            }
 
             if (isDeleteDialogVisible) {
                 CommonDeleteDialog(
@@ -125,21 +160,7 @@ fun ScrapDetailScreen(
                 onBack = onBack,
                 onClipboardCopy = { url -> context.copyToClipboard(url) },
                 onImageClick = { url -> context.openUrl(url) },
-                modifier = modifier,
-                onDelete = { viewModel.showDeleteDialog() },
-                onEditMemo = onEditMemo,
-                onMove = onMove,
-                onShare = { shareScrap(context, scrapItem) },
-                onToggleFavorite = {
-                    viewModel.toggleFavorite(
-                        onSuccess = {},
-                        onFailure = {
-                            Toast
-                                .makeText(context, "즐겨찾기 실패", Toast.LENGTH_SHORT)
-                                .show()
-                        }
-                    )
-                }
+                modifier = modifier
             )
         }
     }
@@ -149,28 +170,12 @@ fun ScrapDetailScreen(
 fun ScrapDetailContent(
     scrapItem: ScrapItem,
     onBack: () -> Unit,
-    onEditMemo: (String) -> Unit,
-    onMove: () -> Unit,
     onClipboardCopy: (String) -> Unit,
     onImageClick: (String) -> Unit,
-    modifier: Modifier = Modifier,
-    onDelete: () -> Unit = {},
-    onShare: () -> Unit = {},
-    onToggleFavorite: () -> Unit = {}
+    modifier: Modifier = Modifier
 ) {
     Scaffold(
         topBar = { DetailTopBar(title = scrapItem.title, onBackClick = onBack) },
-        bottomBar = {
-            DetailBottomBar(
-                isFavorite = scrapItem.isFavorite,
-                onDelete = onDelete,
-                initialMemo = scrapItem.memo,
-                onEditMemo = onEditMemo,
-                onShare = onShare,
-                onMove = onMove,
-                onToggleFavorite = onToggleFavorite
-            )
-        },
         containerColor = BackgroundColor
     ) { innerPadding ->
         Column(
@@ -530,8 +535,6 @@ fun FullDataPreview() {
         ScrapDetailContent(
             scrapItem = scrapItem,
             onBack = {},
-            onEditMemo = {},
-            onMove = {},
             onClipboardCopy = {},
             onImageClick = {}
         )
@@ -556,9 +559,7 @@ fun NoImageAndMemoPreview() {
             scrapItem,
             onBack = {},
             onClipboardCopy = {},
-            onImageClick = {},
-            onEditMemo = {},
-            onMove = {}
+            onImageClick = {}
         )
     }
 }
@@ -581,10 +582,8 @@ fun DarkModePreview() {
         ScrapDetailContent(
             scrapItem = scrapItem,
             onBack = {},
-            onEditMemo = {},
             onClipboardCopy = {},
-            onImageClick = {},
-            onMove = {}
+            onImageClick = {}
         )
     }
 }


### PR DESCRIPTION
## Summary
- 스크랩 상세 화면에서 뒤로가기 시 상세 화면의 `DetailBottomBar`와 목록 화면의 `BottomNavigationBar`가 전환 애니메이션 중 동시에 렌더링되어 하단 바가 이중으로 보이는 현상 수정
- `DetailBottomBar`를 `ScrapDetailScreen` 내부 Scaffold의 `bottomBar` 슬롯에서 제거하고, 기존 선택 모드 바(`ScrapSelectionBottomBar`)와 동일하게 `MainViewModel.customBottomBar`를 통해 `MainScreen`의 단일 슬롯에서 관리하도록 변경
- 화면 진입 시 `LaunchedEffect(isFavorite)`로 바를 등록, 화면 이탈(컴포지션 해제) 시 `DisposableEffect`로 초기화

Fixes #156

## Why
기존에는 두 개의 Scaffold(`MainScreen`, `ScrapDetailScreen`)가 각자 `bottomBar`를 가지고 있어, 뒤로가기 전환 애니메이션 중 일시적으로 두 바가 동시에 화면에 존재했습니다. 단일 슬롯 교체 방식으로 변경하여 바가 위로 올라가며 사라지는 현상 없이 제자리에서 교체되도록 했습니다.

## Note
동일한 구조적 문제가 `AddCategoryScreen`, `CategorySelectionScreen`에도 있을 수 있어, 바텀바 슬롯을 `MainViewModel`에서 분리한 전용 `BottomBarViewModel`로 통합하는 후속 리팩토링을 별도 브랜치(`refactor/unify-bottom-bar-host`)에서 진행 중입니다. 이 PR은 원래 보고된 단일 버그(#156) 수정 범위로 유지합니다.

## Test plan
- [ ] 스크랩 목록 → 상세 진입 시 `DetailBottomBar` 정상 표시 확인
- [ ] 상세 → 목록 복귀(뒤로가기) 시 바가 이중으로 보이지 않고 제자리에서 교체되는지 확인
- [ ] 즐겨찾기 토글 시 바의 아이콘 상태가 즉시 반영되는지 확인
- [ ] 삭제 후 목록 복귀 시에도 바 전환이 정상 동작하는지 확인
- [ ] 즐겨찾기 탭(`FavoriteGraph`)에서 상세 진입 후 복귀 시에도 동일하게 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)