### PR TITLE
feat: 선택모드 삭제 시 확인 다이얼로그 추가

### DIFF
--- a/app/src/main/java/com/scrap2025/scrap2025/ui/favorite/screens/FavoriteScreen.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/favorite/screens/FavoriteScreen.kt
@@ -13,9 +13,12 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import com.scrap2025.scrap2025.ui.common.dialogs.CommonDeleteDialog
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.paging.compose.collectAsLazyPagingItems
@@ -71,9 +74,23 @@ fun FavoriteScreen(
     val pagedItems =
         (uiState.scrapItemsState as? ScrapUiState.Paged)?.pagedData?.collectAsLazyPagingItems()
 
+    var showSelectionDeleteDialog by remember { mutableStateOf(false) }
+
+    if (showSelectionDeleteDialog) {
+        CommonDeleteDialog(
+            title = "선택한 스크랩을 삭제하시겠습니까?",
+            confirmText = "삭제하기",
+            onDismiss = { showSelectionDeleteDialog = false },
+            onConfirm = {
+                showSelectionDeleteDialog = false
+                viewModel.deleteSelectedItems()
+            }
+        )
+    }
+
     val selectionBottomBar: @Composable () -> Unit = {
         ScrapSelectionBottomBar(
-            onDelete = { viewModel.deleteSelectedItems() },
+            onDelete = { showSelectionDeleteDialog = true },
             onMove = {
                 navigateToCategorySelection(uiState.selectedScrapIds.toList())
                 viewModel.exitSelectionMode()

--- a/app/src/main/java/com/scrap2025/scrap2025/ui/favorite/screens/FavoriteScreen.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/favorite/screens/FavoriteScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import com.scrap2025.scrap2025.ui.common.dialogs.CommonDeleteDialog
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.paging.compose.collectAsLazyPagingItems
@@ -26,6 +25,7 @@ import com.scrap2025.scrap2025.model.ScrapItem
 import com.scrap2025.scrap2025.model.enums.ViewMode
 import com.scrap2025.scrap2025.ui.common.components.ScrapSearchBar
 import com.scrap2025.scrap2025.ui.common.components.SortBar
+import com.scrap2025.scrap2025.ui.common.dialogs.CommonDeleteDialog
 import com.scrap2025.scrap2025.ui.scrap.components.ScrapFloatingButtons
 import com.scrap2025.scrap2025.ui.scrap.components.ScrapListContent
 import com.scrap2025.scrap2025.ui.scrap.components.ScrapSelectionBottomBar

--- a/app/src/main/java/com/scrap2025/scrap2025/ui/scrap/screens/ScrapScreen.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/scrap/screens/ScrapScreen.kt
@@ -416,12 +416,25 @@ private fun SetSelectionBottomBar(
     mainViewModel: MainViewModel
 ) {
     val context = LocalContext.current
+    var showSelectionDeleteDialog by remember { mutableStateOf(false) }
+
+    if (showSelectionDeleteDialog) {
+        CommonDeleteDialog(
+            title = "선택한 스크랩을 삭제하시겠습니까?",
+            confirmText = "삭제하기",
+            onDismiss = { showSelectionDeleteDialog = false },
+            onConfirm = {
+                showSelectionDeleteDialog = false
+                scrapViewModel.deleteSelectedItems()
+            }
+        )
+    }
 
     LaunchedEffect(isSelectionMode, uiState, pagedItems) {
         if (isSelectionMode) {
             mainViewModel.setBottomBar {
                 ScrapSelectionBottomBar(
-                    onDelete = { scrapViewModel.deleteSelectedItems() },
+                    onDelete = { showSelectionDeleteDialog = true },
                     onMove = {
                         navigateToCategorySelection()
                         scrapViewModel.exitSelectionMode()


### PR DESCRIPTION
Closes #169

## Summary
- 선택모드(멀티셀렉트)에서 삭제 버튼을 누르면 확인 없이 즉시 삭제되던 문제를 수정
- 기존에 존재하는 `CommonDeleteDialog` 컴포넌트를 재사용하여 삭제 전 확인 다이얼로그를 표시하도록 변경
- 단건 삭제(ScrapDetailScreen), 카테고리 삭제(ScrapScreen)에는 이미 확인 다이얼로그가 있었으나 선택 삭제(bulk delete)에만 누락되어 있던 부분을 보완

## Changes
- `ScrapScreen.kt`: `SetSelectionBottomBar`에 `showSelectionDeleteDialog` 상태 추가, 삭제 버튼 클릭 시 다이얼로그 표시 후 확인 시 `deleteSelectedItems()` 호출
- `FavoriteScreen.kt`: 동일한 패턴 적용

## Test plan
- [ ] 스크랩 목록에서 아이템 롱클릭 → 선택모드 진입 → 삭제 버튼 탭 → 확인 다이얼로그 표시 확인
- [ ] "취소" 클릭 시 다이얼로그만 닫히고 선택 상태 유지되는지 확인
- [ ] "삭제하기" 클릭 시 실제 삭제 및 선택모드 종료 확인
- [ ] 즐겨찾기 화면에서도 동일하게 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)