### PR TITLE
fix: 로그인 에러 발생 시 플레이버별 UX 개선

### DIFF
--- a/app/src/main/java/com/scrap2025/scrap2025/ui/common/components/ErrorScreen.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/common/components/ErrorScreen.kt
@@ -2,29 +2,40 @@ package com.scrap2025.scrap2025.ui.common.components
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.scrap2025.scrap2025.ui.theme.GrayColor
 
 @Composable
-fun ErrorScreen(errorText: String) {
+fun ErrorScreen(errorText: String, onRetry: (() -> Unit)? = null) {
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Text(
                 text = errorText,
-                style =
-                TextStyle(
+                style = TextStyle(
                     fontSize = 16.sp,
                     fontWeight = FontWeight.Medium
                 ),
-                color = GrayColor
+                color = GrayColor,
+                modifier = Modifier.padding(horizontal = 24.dp)
             )
+            if (onRetry != null) {
+                Spacer(modifier = Modifier.height(24.dp))
+                Button(onClick = onRetry) {
+                    Text("다시 시도")
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/scrap2025/scrap2025/ui/login/screens/LoginScreen.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/login/screens/LoginScreen.kt
@@ -1,6 +1,8 @@
 package com.scrap2025.scrap2025.ui.login.screens
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarHost
@@ -113,19 +115,21 @@ private fun ProdLoginScreen(
                 Snackbar(snackbarData = data)
             }
         }
-    ) { _ ->
-        when (uiState) {
-            LoginUiState.Idle, is LoginUiState.Error -> {
-                LoginScreenContent(
-                    onLoginClick = { snsType ->
-                        viewModel.login(snsType) { provider -> provider.login(context) }
-                    },
-                    onTestLogin = { viewModel.loginWithTestToken() },
-                    modifier = modifier
-                )
-            }
-            LoginUiState.Loading, LoginUiState.Success -> {
-                LoadingScreen("로그인 중 ...")
+    ) { innerPadding ->
+        Box(modifier = Modifier.padding(innerPadding)) {
+            when (uiState) {
+                LoginUiState.Idle, is LoginUiState.Error -> {
+                    LoginScreenContent(
+                        onLoginClick = { snsType ->
+                            viewModel.login(snsType) { provider -> provider.login(context) }
+                        },
+                        onTestLogin = { viewModel.loginWithTestToken() },
+                        modifier = modifier
+                    )
+                }
+                LoginUiState.Loading, LoginUiState.Success -> {
+                    LoadingScreen("로그인 중 ...")
+                }
             }
         }
     }

--- a/app/src/main/java/com/scrap2025/scrap2025/ui/login/screens/LoginScreen.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/login/screens/LoginScreen.kt
@@ -1,12 +1,19 @@
 package com.scrap2025.scrap2025.ui.login.screens
 
+import androidx.activity.compose.BackHandler
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.scrap2025.scrap2025.BuildConfig
 import com.scrap2025.scrap2025.ui.common.components.ErrorScreen
 import com.scrap2025.scrap2025.ui.common.components.LoadingScreen
 import com.scrap2025.scrap2025.ui.common.utils.BackPressToExitHandler
@@ -29,7 +36,26 @@ fun LoginScreen(
         }
     }
 
-    BackPressToExitHandler()
+    if (BuildConfig.FLAVOR == "prod") {
+        ProdLoginScreen(uiState = uiState, viewModel = viewModel, modifier = modifier, context = context)
+    } else {
+        DevLoginScreen(uiState = uiState, viewModel = viewModel, modifier = modifier, context = context)
+    }
+}
+
+@Composable
+private fun DevLoginScreen(
+    uiState: LoginUiState,
+    viewModel: LoginViewModel,
+    modifier: Modifier,
+    context: android.content.Context
+) {
+    // 에러 상태에서는 뒤로가기로 Idle 복귀, 그 외에는 앱 종료 핸들러
+    if (uiState is LoginUiState.Error) {
+        BackHandler { viewModel.resetError() }
+    } else {
+        BackPressToExitHandler()
+    }
 
     when (uiState) {
         LoginUiState.Idle -> {
@@ -41,13 +67,56 @@ fun LoginScreen(
                 modifier = modifier
             )
         }
-
         LoginUiState.Loading, LoginUiState.Success -> {
             LoadingScreen("로그인 중 ...")
         }
-
         is LoginUiState.Error -> {
-            ErrorScreen((uiState as LoginUiState.Error).message)
+            ErrorScreen(
+                errorText = uiState.message,
+                onRetry = { viewModel.resetError() }
+            )
+        }
+    }
+}
+
+@Composable
+private fun ProdLoginScreen(
+    uiState: LoginUiState,
+    viewModel: LoginViewModel,
+    modifier: Modifier,
+    context: android.content.Context
+) {
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    BackPressToExitHandler()
+
+    LaunchedEffect(uiState) {
+        if (uiState is LoginUiState.Error) {
+            snackbarHostState.showSnackbar("로그인에 실패했습니다. 다시 시도해 주세요.")
+            viewModel.resetError()
+        }
+    }
+
+    Scaffold(
+        snackbarHost = {
+            SnackbarHost(snackbarHostState) { data ->
+                Snackbar(snackbarData = data)
+            }
+        }
+    ) { _ ->
+        when (uiState) {
+            LoginUiState.Idle, is LoginUiState.Error -> {
+                LoginScreenContent(
+                    onLoginClick = { snsType ->
+                        viewModel.login(snsType) { provider -> provider.login(context) }
+                    },
+                    onTestLogin = { viewModel.loginWithTestToken() },
+                    modifier = modifier
+                )
+            }
+            LoginUiState.Loading, LoginUiState.Success -> {
+                LoadingScreen("로그인 중 ...")
+            }
         }
     }
 }

--- a/app/src/main/java/com/scrap2025/scrap2025/ui/login/screens/LoginScreen.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/login/screens/LoginScreen.kt
@@ -37,9 +37,19 @@ fun LoginScreen(
     }
 
     if (BuildConfig.FLAVOR == "prod") {
-        ProdLoginScreen(uiState = uiState, viewModel = viewModel, modifier = modifier, context = context)
+        ProdLoginScreen(
+            uiState = uiState,
+            viewModel = viewModel,
+            modifier = modifier,
+            context = context
+        )
     } else {
-        DevLoginScreen(uiState = uiState, viewModel = viewModel, modifier = modifier, context = context)
+        DevLoginScreen(
+            uiState = uiState,
+            viewModel = viewModel,
+            modifier = modifier,
+            context = context
+        )
     }
 }
 

--- a/app/src/main/java/com/scrap2025/scrap2025/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/viewmodel/LoginViewModel.kt
@@ -59,6 +59,10 @@ constructor(
         }
     }
 
+    fun resetError() {
+        _uiState.value = LoginUiState.Idle
+    }
+
     fun login(
         snsType: SnsType,
         socialLoginCallback: suspend (SocialLoginProvider) -> Result<String>


### PR DESCRIPTION
## Summary
- 로그인 실패 시 에러 화면에서 빠져나갈 방법이 없어 앱을 재시작해야 했던 문제 수정
- dev/prod 플레이버에 맞춰 에러 UX를 다르게 적용

Closes #94

## 변경 사항
- **dev**: 기존 `ErrorScreen` 유지(디버깅용 상세 메시지) + "다시 시도" 버튼 추가, 뒤로가기 시 로그인 화면으로 복귀 (앱 종료 방지)
- **prod**: 로그인 화면을 유지한 채 Snackbar로 사용자 친화적 메시지(`"로그인에 실패했습니다. 다시 시도해 주세요."`) 표시 후 자동으로 Idle 복귀
- `LoginViewModel`에 `resetError()` 추가

## Test plan
- [ ] dev 빌드: 네트워크 차단 상태에서 로그인 시도 → ErrorScreen + 다시 시도 버튼 표시 → 버튼 탭 시 로그인 화면 복귀 확인
- [ ] dev 빌드: 에러 상태에서 뒤로가기 → 앱 종료 대신 로그인 화면 복귀 확인
- [ ] prod 빌드: 동일 조건에서 Snackbar 표시 + 로그인 화면 유지 확인 → 즉시 재시도 가능 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)