### PR TITLE
fix: 스크랩 이미지 롱 프레스 시 선택 모드 진입하도록 수정

### DIFF
--- a/app/src/main/java/com/scrap2025/scrap2025/ui/scrap/components/ScrapItemCardGrid.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/scrap/components/ScrapItemCardGrid.kt
@@ -2,7 +2,6 @@ package com.scrap2025.scrap2025.ui.scrap.components
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -95,13 +94,20 @@ fun ScrapItemCardGrid(
                                 topEnd = 15.dp
                             )
                         )
-                        .clickable {
-                            if (isSelectionMode) {
-                                onSelectionToggle()
-                            } else {
-                                context.openUrl(scrapItem.url)
+                        .combinedClickable(
+                            onClick = {
+                                if (isSelectionMode) {
+                                    onSelectionToggle()
+                                } else {
+                                    context.openUrl(scrapItem.url)
+                                }
+                            },
+                            onLongClick = {
+                                if (!isSelectionMode) {
+                                    onLongClick()
+                                }
                             }
-                        },
+                        ),
                     contentAlignment = Alignment.Center
                 ) {
                     ScrapImage(

--- a/app/src/main/java/com/scrap2025/scrap2025/ui/scrap/components/ScrapItemCardList.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/scrap/components/ScrapItemCardList.kt
@@ -3,7 +3,6 @@ package com.scrap2025.scrap2025.ui.scrap.components
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -100,13 +99,20 @@ fun ScrapItemCardList(
                             color = LightGrayColor,
                             shape = RoundedCornerShape(4.dp)
                         )
-                        .clickable {
-                            if (isSelectionMode) {
-                                onSelectionToggle()
-                            } else {
-                                context.openUrl(scrapItem.url)
+                        .combinedClickable(
+                            onClick = {
+                                if (isSelectionMode) {
+                                    onSelectionToggle()
+                                } else {
+                                    context.openUrl(scrapItem.url)
+                                }
+                            },
+                            onLongClick = {
+                                if (!isSelectionMode) {
+                                    onLongClick()
+                                }
                             }
-                        },
+                        ),
                     contentAlignment = Alignment.Center
                 ) {
                     ScrapImage(


### PR DESCRIPTION
Closes #155

## Summary
- 스크랩 카드의 이미지 영역을 롱 프레스하면 선택 모드가 아닌 URL 바로가기가 실행되던 버그 수정
- 이미지 영역의 `.clickable`을 `.combinedClickable`로 교체해 카드 전체와 동일하게 `onLongClick` 시 선택 모드로 진입하도록 처리 (리스트/그리드 뷰 모두)

## Why
이미지 영역에 별도의 `.clickable`이 있어 롱 프레스 제스처를 소비한 뒤 손을 떼는 순간 `onClick`(URL 열기)이 발생, 부모 카드의 `combinedClickable.onLongClick`(선택 모드 진입)이 무시되는 문제였습니다.

## Test plan
- [ ] 스크랩 리스트 화면에서 이미지 영역 롱 프레스 시 선택 모드로 진입하는지 확인
- [ ] 스크랩 그리드 화면에서 이미지 영역 롱 프레스 시 선택 모드로 진입하는지 확인
- [ ] 일반 탭(짧은 클릭) 시 기존처럼 URL이 정상적으로 열리는지 확인
- [ ] 선택 모드 중 이미지 탭 시 선택 토글이 정상 동작하는지 확인