### PR TITLE
fix: 선택모드에서 뒤로가기 시 앱 종료 동작 수정

### DIFF
--- a/app/src/main/java/com/scrap2025/scrap2025/ui/main/screens/MainScreen.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/main/screens/MainScreen.kt
@@ -64,11 +64,11 @@ fun MainScreen(
             currentDestination?.hasRoute<Search>() == true ||
             currentDestination?.hasRoute<MyPage>() == true
 
-    if (isMainTab) {
+    val customBottomBar by mainViewModel.customBottomBar.collectAsState()
+
+    if (isMainTab && customBottomBar == null) {
         BackPressToExitHandler()
     }
-
-    val customBottomBar by mainViewModel.customBottomBar.collectAsState()
     val sharedUrl by mainViewModel.sharedUrl.collectAsState()
 
     // 공유된 URL이 있으면 AddScrapScreen으로 이동


### PR DESCRIPTION
## Summary
- 선택모드 활성화 중에도 `BackPressToExitHandler`가 항상 켜져 있어, 선택모드에서 뒤로가기를 누르면 선택모드 종료가 아닌 앱 종료 토스트/동작이 먼저 반응하던 문제 수정
- `customBottomBar`(선택모드 시 표시되는 커스텀 하단바)가 설정되어 있을 때는 종료 핸들러를 비활성화하도록 조건 추가

## Why
선택모드의 `BackHandler(enabled = isSelectionMode)`가 이론상 우선순위를 가져야 하지만, Navigation Compose의 Predictive Back 처리와 겹쳐 `BackPressToExitHandler`가 먼저 반응하는 문제가 있었음. 선택모드 중에는 종료 핸들러 자체를 비활성화하여 충돌을 원천적으로 제거.

Closes #168

## Test plan
- [ ] 스크랩/즐겨찾기 화면에서 아이템 롱클릭 → 선택모드 진입 → 뒤로가기 → 선택모드만 종료되는지 확인
- [ ] 선택모드 종료 후 뒤로가기 → "한번 더 누르면 종료됩니다" 토스트 정상 동작 확인