### PR TITLE
refactor: 바텀바 슬롯을 BottomBarViewModel로 통합

### DIFF
--- a/app/src/main/java/com/scrap2025/scrap2025/ui/category/screens/AddCategoryScreen.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/category/screens/AddCategoryScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -26,6 +27,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModelStoreOwner
 import com.scrap2025.scrap2025.ui.common.buttons.TwoButtons
 import com.scrap2025.scrap2025.ui.common.topbars.TopBarWithBack
 import com.scrap2025.scrap2025.ui.theme.BackgroundColor
@@ -35,13 +37,16 @@ import com.scrap2025.scrap2025.ui.theme.MainColorLight
 import com.scrap2025.scrap2025.ui.theme.Scrap2025Theme
 import com.scrap2025.scrap2025.viewmodel.AddCategoryUiState
 import com.scrap2025.scrap2025.viewmodel.AddCategoryViewModel
+import com.scrap2025.scrap2025.viewmodel.BottomBarViewModel
 
 /** AddCategoryScreen - 카테고리 추가 화면 ViewModel을 통해 카테고리를 추가하고, Result 상태를 처리 */
 @Composable
 fun AddCategoryScreen(
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
-    viewModel: AddCategoryViewModel = hiltViewModel()
+    viewModel: AddCategoryViewModel = hiltViewModel(),
+    bottomBarViewModel: BottomBarViewModel =
+        hiltViewModel(viewModelStoreOwner = LocalContext.current as ViewModelStoreOwner)
 ) {
     val addCategoryState by viewModel.addCategoryUiState.collectAsState()
     val context = LocalContext.current
@@ -77,13 +82,27 @@ fun AddCategoryScreen(
         }
     }
 
+    LaunchedEffect(addCategoryState is AddCategoryUiState.Loading) {
+        bottomBarViewModel.setBottomBar {
+            TwoButtons(
+                confirmText = "추가하기",
+                onCancel = handleBack,
+                onConfirm = { viewModel.addCategory() },
+                isLoading = addCategoryState is AddCategoryUiState.Loading
+            )
+        }
+    }
+
+    DisposableEffect(Unit) {
+        onDispose { bottomBarViewModel.setBottomBar(null) }
+    }
+
     AddCategoryScreenContent(
         modifier = modifier,
         onBack = handleBack,
         categoryTitleInput = categoryTitleInput,
         onValueChange = { newName -> viewModel.updateCategoryTitle(newName) },
-        addCategoryUiState = addCategoryState,
-        onAddCategory = { viewModel.addCategory() }
+        addCategoryUiState = addCategoryState
     )
 }
 
@@ -93,21 +112,12 @@ fun AddCategoryScreenContent(
     onBack: () -> Unit,
     categoryTitleInput: String,
     onValueChange: (String) -> Unit,
-    addCategoryUiState: AddCategoryUiState?,
-    onAddCategory: () -> Unit
+    addCategoryUiState: AddCategoryUiState?
 ) {
     Scaffold(
         modifier = modifier.fillMaxSize(),
         containerColor = BackgroundColor,
-        topBar = { TopBarWithBack(title = "카테고리 추가하기", onBack = onBack) },
-        bottomBar = {
-            TwoButtons(
-                confirmText = "추가하기",
-                onCancel = onBack,
-                onConfirm = onAddCategory,
-                isLoading = addCategoryUiState is AddCategoryUiState.Loading
-            )
-        }
+        topBar = { TopBarWithBack(title = "카테고리 추가하기", onBack = onBack) }
     ) { innerPadding ->
         Box(
             modifier =
@@ -181,8 +191,7 @@ fun AddCategoryScreenContentPreview() {
             onBack = {},
             categoryTitleInput = "",
             onValueChange = {},
-            addCategoryUiState = null,
-            onAddCategory = {}
+            addCategoryUiState = null
         )
     }
 }

--- a/app/src/main/java/com/scrap2025/scrap2025/ui/category/screens/CategorySelectionScreen.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/category/screens/CategorySelectionScreen.kt
@@ -18,6 +18,8 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -25,6 +27,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModelStoreOwner
 import com.scrap2025.scrap2025.model.CategoryItem
 import com.scrap2025.scrap2025.ui.category.components.CategoryItemCard
 import com.scrap2025.scrap2025.ui.common.buttons.TwoButtons
@@ -35,6 +38,7 @@ import com.scrap2025.scrap2025.ui.theme.BackgroundColor
 import com.scrap2025.scrap2025.ui.theme.GrayColor
 import com.scrap2025.scrap2025.ui.theme.MainColor
 import com.scrap2025.scrap2025.ui.theme.MainColorDeep
+import com.scrap2025.scrap2025.viewmodel.BottomBarViewModel
 import com.scrap2025.scrap2025.viewmodel.CategorySelectionViewModel
 import com.scrap2025.scrap2025.viewmodel.CategoryUiState
 
@@ -51,7 +55,9 @@ fun CategorySelectionScreen(
     onConfirmAdd: (Long, String) -> Unit,
     onConfirmSearch: (List<Long>) -> Unit,
     modifier: Modifier = Modifier,
-    viewModel: CategorySelectionViewModel = hiltViewModel()
+    viewModel: CategorySelectionViewModel = hiltViewModel(),
+    bottomBarViewModel: BottomBarViewModel =
+        hiltViewModel(viewModelStoreOwner = LocalContext.current as ViewModelStoreOwner)
 ) {
     val context = LocalContext.current
     val mode = viewModel.mode
@@ -106,6 +112,16 @@ fun CategorySelectionScreen(
         }
     }
 
+    LaunchedEffect(selectedCategoryId, selectedCategoryName, selectedCategoryIds) {
+        bottomBarViewModel.setBottomBar {
+            TwoButtons(confirmText = confirmText, onCancel = onBack, onConfirm = onConfirm())
+        }
+    }
+
+    DisposableEffect(Unit) {
+        onDispose { bottomBarViewModel.setBottomBar(null) }
+    }
+
     when (val state = uiState) {
         is CategoryUiState.Loading -> {
             LoadingScreen()
@@ -122,7 +138,6 @@ fun CategorySelectionScreen(
                 selectedCategoryIds = selectedCategoryIds,
                 isMultiSelect = mode == Mode.SEARCH,
                 title = title,
-                confirmText = confirmText,
                 onBack = onBack,
                 onCategoryClick = { id, title ->
                     if (mode == Mode.SEARCH) {
@@ -132,7 +147,6 @@ fun CategorySelectionScreen(
                     }
                 },
                 onAddClick = onAddClick,
-                onConfirm = onConfirm(),
                 modifier = modifier
             )
         }
@@ -146,18 +160,13 @@ fun CategorySelectionScreenContent(
     selectedCategoryIds: Set<Long>,
     isMultiSelect: Boolean,
     title: String,
-    confirmText: String,
     onBack: () -> Unit,
     onCategoryClick: (Long, String) -> Unit,
     onAddClick: () -> Unit,
-    onConfirm: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Scaffold(
         topBar = { TopBarWithBack(title = title, onBack = onBack) },
-        bottomBar = {
-            TwoButtons(confirmText = confirmText, onCancel = onBack, onConfirm = onConfirm)
-        },
         floatingActionButton = {
             FloatingActionButton(
                 onClick = onAddClick,
@@ -231,9 +240,7 @@ fun CategorySelectionScreenContentPreview() {
         selectedCategoryIds = emptySet(),
         isMultiSelect = false,
         title = "카테고리 선택",
-        confirmText = "이동",
         onBack = {},
-        onConfirm = {},
         onCategoryClick = { _, _ -> },
         onAddClick = {}
     )

--- a/app/src/main/java/com/scrap2025/scrap2025/ui/common/buttons/TwoButtons.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/common/buttons/TwoButtons.kt
@@ -2,10 +2,13 @@ package com.scrap2025.scrap2025.ui.common.buttons
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -34,6 +37,7 @@ fun TwoButtons(
         modifier =
         modifier
             .fillMaxWidth()
+            .windowInsetsPadding(WindowInsets.navigationBars)
             .padding(all = 22.dp),
         horizontalArrangement = Arrangement.spacedBy(12.dp)
     ) {

--- a/app/src/main/java/com/scrap2025/scrap2025/ui/favorite/screens/FavoriteScreen.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/favorite/screens/FavoriteScreen.kt
@@ -30,8 +30,8 @@ import com.scrap2025.scrap2025.ui.scrap.components.ScrapTopBar
 import com.scrap2025.scrap2025.ui.scrap.components.SelectionTopBar
 import com.scrap2025.scrap2025.ui.scrap.screens.ScrapScreenContent
 import com.scrap2025.scrap2025.utils.isScrolled
+import com.scrap2025.scrap2025.viewmodel.BottomBarViewModel
 import com.scrap2025.scrap2025.viewmodel.FavoriteViewModel
-import com.scrap2025.scrap2025.viewmodel.MainViewModel
 import com.scrap2025.scrap2025.viewmodel.ScrapUiState
 
 @Stable
@@ -61,7 +61,7 @@ fun FavoriteScreen(
     navigateToCategorySelection: (List<Long>) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: FavoriteViewModel = hiltViewModel(),
-    mainViewModel: MainViewModel =
+    bottomBarViewModel: BottomBarViewModel =
         hiltViewModel(viewModelStoreOwner = LocalContext.current as ViewModelStoreOwner)
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -104,8 +104,8 @@ fun FavoriteScreen(
 
     LaunchedEffect(uiState.isSelectionMode, uiState, pagedItems) {
         when (uiState.isSelectionMode) {
-            true -> mainViewModel.setBottomBar(selectionBottomBar)
-            false -> mainViewModel.setBottomBar(null)
+            true -> bottomBarViewModel.setBottomBar(selectionBottomBar)
+            false -> bottomBarViewModel.setBottomBar(null)
         }
     }
 

--- a/app/src/main/java/com/scrap2025/scrap2025/ui/main/screens/MainScreen.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/main/screens/MainScreen.kt
@@ -30,6 +30,7 @@ import com.scrap2025.scrap2025.ui.category.screens.Mode
 import com.scrap2025.scrap2025.ui.common.utils.BackPressToExitHandler
 import com.scrap2025.scrap2025.ui.main.components.BottomNavigationBar
 import com.scrap2025.scrap2025.ui.theme.Scrap2025Theme
+import com.scrap2025.scrap2025.viewmodel.BottomBarViewModel
 import com.scrap2025.scrap2025.viewmodel.MainViewModel
 
 @Composable
@@ -37,6 +38,8 @@ fun MainScreen(
     parentNavController: NavHostController,
     modifier: Modifier = Modifier,
     mainViewModel: MainViewModel =
+        hiltViewModel(viewModelStoreOwner = LocalContext.current as ViewModelStoreOwner),
+    bottomBarViewModel: BottomBarViewModel =
         hiltViewModel(viewModelStoreOwner = LocalContext.current as ViewModelStoreOwner)
 ) {
     val tabNavController = rememberNavController()
@@ -68,7 +71,7 @@ fun MainScreen(
         BackPressToExitHandler()
     }
 
-    val customBottomBar by mainViewModel.customBottomBar.collectAsState()
+    val customBottomBar by bottomBarViewModel.bottomBar.collectAsState()
     val sharedUrl by mainViewModel.sharedUrl.collectAsState()
 
     // 공유된 URL이 있으면 AddScrapScreen으로 이동

--- a/app/src/main/java/com/scrap2025/scrap2025/ui/scrap/screens/ScrapDetailScreen.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/scrap/screens/ScrapDetailScreen.kt
@@ -30,6 +30,8 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -48,6 +50,7 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import com.gigamole.composeshadowsplus.common.ShadowsPlusType
@@ -66,6 +69,7 @@ import com.scrap2025.scrap2025.ui.theme.Scrap2025Theme
 import com.scrap2025.scrap2025.ui.theme.WarningColor
 import com.scrap2025.scrap2025.utils.copyToClipboard
 import com.scrap2025.scrap2025.utils.openUrl
+import com.scrap2025.scrap2025.viewmodel.BottomBarViewModel
 import com.scrap2025.scrap2025.viewmodel.ScrapDetailUiState
 import com.scrap2025.scrap2025.viewmodel.ScrapDetailViewModel
 import java.time.LocalDateTime
@@ -76,11 +80,17 @@ fun ScrapDetailScreen(
     onEditMemo: (String) -> Unit,
     onMove: () -> Unit,
     modifier: Modifier = Modifier,
-    viewModel: ScrapDetailViewModel = hiltViewModel()
+    viewModel: ScrapDetailViewModel = hiltViewModel(),
+    bottomBarViewModel: BottomBarViewModel =
+        hiltViewModel(viewModelStoreOwner = LocalContext.current as ViewModelStoreOwner)
 ) {
     val context = LocalContext.current
 
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    DisposableEffect(Unit) {
+        onDispose { bottomBarViewModel.setBottomBar(null) }
+    }
 
     when (val state = uiState) {
         is ScrapDetailUiState.Loading -> LoadingScreen()
@@ -96,6 +106,29 @@ fun ScrapDetailScreen(
             val scrapItem = state.scrapItem
             val isDeleteDialogVisible by
                 viewModel.isDeleteDialogVisible.collectAsStateWithLifecycle()
+
+            LaunchedEffect(scrapItem.isFavorite) {
+                bottomBarViewModel.setBottomBar {
+                    DetailBottomBar(
+                        isFavorite = scrapItem.isFavorite,
+                        onDelete = { viewModel.showDeleteDialog() },
+                        initialMemo = scrapItem.memo,
+                        onEditMemo = onEditMemo,
+                        onShare = { shareScrap(context, scrapItem) },
+                        onMove = onMove,
+                        onToggleFavorite = {
+                            viewModel.toggleFavorite(
+                                onSuccess = {},
+                                onFailure = {
+                                    Toast
+                                        .makeText(context, "즐겨찾기 실패", Toast.LENGTH_SHORT)
+                                        .show()
+                                }
+                            )
+                        }
+                    )
+                }
+            }
 
             if (isDeleteDialogVisible) {
                 CommonDeleteDialog(
@@ -125,21 +158,7 @@ fun ScrapDetailScreen(
                 onBack = onBack,
                 onClipboardCopy = { url -> context.copyToClipboard(url) },
                 onImageClick = { url -> context.openUrl(url) },
-                modifier = modifier,
-                onDelete = { viewModel.showDeleteDialog() },
-                onEditMemo = onEditMemo,
-                onMove = onMove,
-                onShare = { shareScrap(context, scrapItem) },
-                onToggleFavorite = {
-                    viewModel.toggleFavorite(
-                        onSuccess = {},
-                        onFailure = {
-                            Toast
-                                .makeText(context, "즐겨찾기 실패", Toast.LENGTH_SHORT)
-                                .show()
-                        }
-                    )
-                }
+                modifier = modifier
             )
         }
     }
@@ -149,28 +168,12 @@ fun ScrapDetailScreen(
 fun ScrapDetailContent(
     scrapItem: ScrapItem,
     onBack: () -> Unit,
-    onEditMemo: (String) -> Unit,
-    onMove: () -> Unit,
     onClipboardCopy: (String) -> Unit,
     onImageClick: (String) -> Unit,
-    modifier: Modifier = Modifier,
-    onDelete: () -> Unit = {},
-    onShare: () -> Unit = {},
-    onToggleFavorite: () -> Unit = {}
+    modifier: Modifier = Modifier
 ) {
     Scaffold(
         topBar = { DetailTopBar(title = scrapItem.title, onBackClick = onBack) },
-        bottomBar = {
-            DetailBottomBar(
-                isFavorite = scrapItem.isFavorite,
-                onDelete = onDelete,
-                initialMemo = scrapItem.memo,
-                onEditMemo = onEditMemo,
-                onShare = onShare,
-                onMove = onMove,
-                onToggleFavorite = onToggleFavorite
-            )
-        },
         containerColor = BackgroundColor
     ) { innerPadding ->
         Column(
@@ -530,8 +533,6 @@ fun FullDataPreview() {
         ScrapDetailContent(
             scrapItem = scrapItem,
             onBack = {},
-            onEditMemo = {},
-            onMove = {},
             onClipboardCopy = {},
             onImageClick = {}
         )
@@ -556,9 +557,7 @@ fun NoImageAndMemoPreview() {
             scrapItem,
             onBack = {},
             onClipboardCopy = {},
-            onImageClick = {},
-            onEditMemo = {},
-            onMove = {}
+            onImageClick = {}
         )
     }
 }
@@ -581,10 +580,8 @@ fun DarkModePreview() {
         ScrapDetailContent(
             scrapItem = scrapItem,
             onBack = {},
-            onEditMemo = {},
             onClipboardCopy = {},
-            onImageClick = {},
-            onMove = {}
+            onImageClick = {}
         )
     }
 }

--- a/app/src/main/java/com/scrap2025/scrap2025/ui/scrap/screens/ScrapDetailScreen.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/scrap/screens/ScrapDetailScreen.kt
@@ -12,13 +12,16 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -415,6 +418,7 @@ fun DetailBottomBar(
                 offset = DpOffset(0.dp, (-3).dp),
                 radius = 15.dp
             ).clip(RoundedCornerShape(topStart = 15.dp, topEnd = 15.dp))
+            .windowInsetsPadding(WindowInsets.navigationBars)
     ) {
         Row(
             modifier =

--- a/app/src/main/java/com/scrap2025/scrap2025/ui/scrap/screens/ScrapScreen.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/scrap/screens/ScrapScreen.kt
@@ -56,6 +56,7 @@ import com.scrap2025.scrap2025.ui.scrap.components.SelectionTopBar
 import com.scrap2025.scrap2025.ui.theme.BackgroundColor
 import com.scrap2025.scrap2025.ui.theme.Scrap2025Theme
 import com.scrap2025.scrap2025.utils.isScrolled
+import com.scrap2025.scrap2025.viewmodel.BottomBarViewModel
 import com.scrap2025.scrap2025.viewmodel.MainViewModel
 import com.scrap2025.scrap2025.viewmodel.ScrapUiState
 import com.scrap2025.scrap2025.viewmodel.ScrapViewModel
@@ -112,6 +113,8 @@ fun ScrapScreen(
     modifier: Modifier = Modifier,
     scrapViewModel: ScrapViewModel = hiltViewModel(),
     mainViewModel: MainViewModel =
+        hiltViewModel(viewModelStoreOwner = LocalContext.current as ViewModelStoreOwner),
+    bottomBarViewModel: BottomBarViewModel =
         hiltViewModel(viewModelStoreOwner = LocalContext.current as ViewModelStoreOwner)
 ) {
     val uiState by scrapViewModel.uiState.collectAsState()
@@ -131,7 +134,7 @@ fun ScrapScreen(
         uiState.isSelectionMode,
         { navigateToCategorySelection(uiState.selectedScrapIds.toList()) },
         scrapViewModel,
-        mainViewModel
+        bottomBarViewModel
     )
     HandleCategoryDeleteEvents(
         scrapViewModel = scrapViewModel,
@@ -413,13 +416,13 @@ private fun SetSelectionBottomBar(
     isSelectionMode: Boolean,
     navigateToCategorySelection: () -> Unit,
     scrapViewModel: ScrapViewModel,
-    mainViewModel: MainViewModel
+    bottomBarViewModel: BottomBarViewModel
 ) {
     val context = LocalContext.current
 
     LaunchedEffect(isSelectionMode, uiState, pagedItems) {
         if (isSelectionMode) {
-            mainViewModel.setBottomBar {
+            bottomBarViewModel.setBottomBar {
                 ScrapSelectionBottomBar(
                     onDelete = { scrapViewModel.deleteSelectedItems() },
                     onMove = {
@@ -449,7 +452,7 @@ private fun SetSelectionBottomBar(
                 )
             }
         } else {
-            mainViewModel.setBottomBar(null)
+            bottomBarViewModel.setBottomBar(null)
         }
     }
 }

--- a/app/src/main/java/com/scrap2025/scrap2025/viewmodel/BottomBarViewModel.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/viewmodel/BottomBarViewModel.kt
@@ -1,0 +1,22 @@
+package com.scrap2025.scrap2025.viewmodel
+
+import androidx.compose.runtime.Composable
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+@HiltViewModel
+class BottomBarViewModel
+@Inject
+constructor() : ViewModel() {
+    private val _bottomBar = MutableStateFlow<(@Composable () -> Unit)?>(null)
+    val bottomBar: StateFlow<(@Composable () -> Unit)?> = _bottomBar.asStateFlow()
+
+    /** 바텀바에 표시할 커스텀 컴포저블을 설정합니다. null을 전달하면 기본 바텀바를 표시합니다. */
+    fun setBottomBar(content: (@Composable () -> Unit)?) {
+        _bottomBar.value = content
+    }
+}

--- a/app/src/main/java/com/scrap2025/scrap2025/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/viewmodel/MainViewModel.kt
@@ -1,6 +1,5 @@
 package com.scrap2025.scrap2025.viewmodel
 
-import androidx.compose.runtime.Composable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.scrap2025.scrap2025.data.local.TokenManager
@@ -38,9 +37,6 @@ constructor(
             initialValue = ""
         )
 
-    private val _customBottomBar = MutableStateFlow<(@Composable () -> Unit)?>(null)
-    val customBottomBar: StateFlow<(@Composable () -> Unit)?> = _customBottomBar.asStateFlow()
-
     private val _sharedUrl = MutableStateFlow<String?>(null)
     val sharedUrl: StateFlow<String?> = _sharedUrl.asStateFlow()
 
@@ -65,11 +61,6 @@ constructor(
                 }
             }
         }
-    }
-
-    /** 바텀바에 표시할 커스텀 컴포저블을 설정합니다. null을 전달하면 기본 바텀바를 표시합니다. */
-    fun setBottomBar(content: (@Composable () -> Unit)?) {
-        _customBottomBar.value = content
     }
 
     /** 다른 앱에서 공유된 URL을 설정하여 네비게이션을 트리거합니다. */


### PR DESCRIPTION
## Summary
- `MainViewModel`에 섞여 있던 `customBottomBar` 상태를 단일 책임 `BottomBarViewModel`로 분리
- `AddCategoryScreen`/`CategorySelectionScreen`이 각자 들고 있던 `Scaffold(bottomBar = ...)`를 동일한 공용 슬롯 패턴으로 통일
  - 두 화면 모두 `popBackStack()`으로 메인 탭에 복귀하는 구조라, `ScrapDetailScreen`에서 발견됐던 것과 같은 구조적 이중 바 표시 위험이 있었음
- `CategorySelectionScreen`은 `LaunchedEffect` 키에 `selectedCategoryId`/`selectedCategoryName`/`selectedCategoryIds`를 모두 포함시켜, 선택 변경이 확인 버튼 콜백에 반영되지 않는 stale closure 회귀를 방지

Related to #156 (원본 버그 수정 pr은 #172 이나 현재 pr에서 처리하므로 close 함)

## Test plan
- [x] `./gradlew :app:compileDevDebugKotlin` 빌드 통과
- [x] `./gradlew :app:ktlintCheck` 통과
- [ ] 스크랩 상세 → 뒤로가기 정상 동작 확인 (회귀 없는지)
- [ ] 스크랩/즐겨찾기 선택모드 진입·해제 시 바 전환 확인
- [ ] 카테고리 추가 화면 진입 → 뒤로가기: 바 이중 표시 없는지 확인
- [ ] 카테고리 선택(이동/추가/검색 3모드) 화면에서 선택 변경 후 확인 버튼 클릭 시 최신 선택값으로 반영되는지 확인