### PR TITLE
feat: 로그인 화면에 마지막 로그인 소셜 계정 표시 기능 추가

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,11 @@ continuation_indent_size = 4
 
 # Composable 함수 PascalCase 허용
 ktlint_function_naming_ignore_when_annotated_with = Composable
+
+# 와일드카드 import 허용
+ij_kotlin_name_count_to_use_star_import = 1
+ij_kotlin_name_count_to_use_star_import_for_members = 1
+
+# trailing comma 허용
+ktlint_standard_trailing-comma-on-call-site = disabled
+ktlint_standard_trailing-comma-on-declaration-site = disabled

--- a/app/src/main/java/com/scrap2025/scrap2025/data/local/PreferencesManager.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/data/local/PreferencesManager.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import com.scrap2025.scrap2025.model.enums.SnsType
 import com.scrap2025.scrap2025.model.enums.SortDirection
 import com.scrap2025.scrap2025.model.enums.SortType
 import com.scrap2025.scrap2025.model.enums.ViewMode
@@ -25,6 +26,7 @@ class PreferencesManager(context: Context) {
         private val IS_DATABASE_INITIALIZED_KEY =
             androidx.datastore.preferences.core
                 .booleanPreferencesKey("is_database_initialized")
+        private val LAST_SNS_TYPE_KEY = stringPreferencesKey("last_sns_type")
     }
 
     // 정렬 타입 Flow (기본값: DATE)
@@ -90,5 +92,17 @@ class PreferencesManager(context: Context) {
     // 데이터베이스 초기화 완료 설정
     suspend fun setDatabaseInitialized(initialized: Boolean) {
         dataStore.edit { preferences -> preferences[IS_DATABASE_INITIALIZED_KEY] = initialized }
+    }
+
+    // 마지막 로그인 SNS 타입 Flow (로그아웃 후에도 유지)
+    val lastLoginSnsType: Flow<SnsType?> =
+        dataStore.data.map { preferences ->
+            preferences[LAST_SNS_TYPE_KEY]?.let { value ->
+                SnsType.entries.find { it.value == value }
+            }
+        }
+
+    suspend fun saveLastLoginSnsType(snsType: SnsType) {
+        dataStore.edit { preferences -> preferences[LAST_SNS_TYPE_KEY] = snsType.value }
     }
 }

--- a/app/src/main/java/com/scrap2025/scrap2025/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/repository/AuthRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.scrap2025.scrap2025.repository
 
 import android.util.Log
 import com.scrap2025.scrap2025.data.local.AppDatabase
+import com.scrap2025.scrap2025.data.local.PreferencesManager
 import com.scrap2025.scrap2025.data.local.TokenManager
 import com.scrap2025.scrap2025.data.remote.datasource.AuthRemoteDataSource
 import com.scrap2025.scrap2025.model.enums.SnsType
@@ -18,7 +19,8 @@ class AuthRepositoryImpl
 constructor(
     private val authRemoteDataSource: AuthRemoteDataSource,
     private val tokenManager: TokenManager,
-    private val database: AppDatabase
+    private val database: AppDatabase,
+    private val preferencesManager: PreferencesManager
 ) : AuthRepository {
     companion object {
         private const val TAG = "AuthRepository"
@@ -48,6 +50,7 @@ constructor(
             refreshToken = loginResult.refreshToken
         )
         tokenManager.saveSnsType(snsType)
+        preferencesManager.saveLastLoginSnsType(snsType)
         Log.d(TAG, "Tokens and SnsType saved successfully")
         Result.success(Unit)
     } catch (e: Exception) {

--- a/app/src/main/java/com/scrap2025/scrap2025/ui/login/components/LoginScreenContent.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/login/components/LoginScreenContent.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -13,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -52,7 +54,12 @@ import androidx.compose.ui.window.DialogProperties
 import com.scrap2025.scrap2025.BuildConfig
 import com.scrap2025.scrap2025.R
 import com.scrap2025.scrap2025.model.enums.SnsType
+import com.scrap2025.scrap2025.model.enums.SnsType.GOOGLE
+import com.scrap2025.scrap2025.model.enums.SnsType.KAKAO
+import com.scrap2025.scrap2025.model.enums.SnsType.NAVER
+import com.scrap2025.scrap2025.model.enums.SnsType.TEST
 import com.scrap2025.scrap2025.ui.theme.GrayColor
+import com.scrap2025.scrap2025.ui.theme.LastLoginBadgeColor
 import com.scrap2025.scrap2025.ui.theme.LightGrayColor
 import com.scrap2025.scrap2025.ui.theme.MainColor
 import com.scrap2025.scrap2025.ui.theme.MainColorDeep
@@ -68,6 +75,7 @@ private val ButtonTextStyle = TextStyle(fontSize = 16.sp, fontWeight = FontWeigh
 fun LoginScreenContent(
     onLoginClick: (SnsType) -> Unit,
     onTestLogin: () -> Unit,
+    lastLoginSnsType: SnsType? = null,
     modifier: Modifier = Modifier
 ) {
     val clickCountState = remember { mutableIntStateOf(0) }
@@ -124,7 +132,8 @@ fun LoginScreenContent(
                     .background(
                         color = MainColor,
                         shape = RoundedCornerShape(30.dp)
-                    ).padding(horizontal = 16.dp, vertical = 8.dp)
+                    )
+                    .padding(horizontal = 16.dp, vertical = 8.dp)
                     .pointerInput(Unit) {
                         detectTapGestures(
                             onTap = {
@@ -143,15 +152,19 @@ fun LoginScreenContent(
                     style = TextStyle(fontSize = 13.sp, fontWeight = FontWeight.Normal)
                 )
             }
-            Spacer(modifier = Modifier.height(20.dp))
-            KakaoLoginButton {
-                onLoginClick(SnsType.KAKAO)
+
+            Column(
+                Modifier.padding(vertical = 20.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                for (snsType in SnsType.entries) {
+                    SocialLoginButton(
+                        snsType = snsType,
+                        lastLoginSnsType = lastLoginSnsType,
+                        onLoginClick = onLoginClick
+                    )
+                }
             }
-            Spacer(modifier = Modifier.height(12.dp))
-            NaverLoginButton {
-                onLoginClick(SnsType.NAVER)
-            }
-            Spacer(modifier = Modifier.height(20.dp))
         }
     }
 
@@ -162,6 +175,55 @@ fun LoginScreenContent(
                 showSecretDialog = false
                 onTestLogin() // 기존 onTestLogin 실행
             }
+        )
+    }
+}
+
+@Composable
+private fun SocialLoginButton(
+    snsType: SnsType,
+    lastLoginSnsType: SnsType?,
+    onLoginClick: (SnsType) -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+    ) {
+        when (snsType) {
+            NAVER -> NaverLoginButton { onLoginClick(snsType) }
+            KAKAO -> KakaoLoginButton { onLoginClick(snsType) }
+            GOOGLE -> {} // 미구현
+            TEST -> {} // 숨겨진 버튼으로 진입
+        }
+        if (snsType == lastLoginSnsType) LastLoginBadge()
+    }
+}
+
+@Composable
+private fun BoxScope.LastLoginBadge() {
+    Box(
+        modifier = Modifier
+            .align(Alignment.TopEnd)
+            .padding(end = 8.dp)
+            .offset(y = (-16).dp)
+            .background(LastLoginBadgeColor, RoundedCornerShape(50))
+            .padding(horizontal = 12.dp, vertical = 5.dp)
+    ) {
+        Text(
+            text = "마지막으로 로그인한 계정",
+            style = TextStyle(
+                fontSize = 11.sp,
+                fontWeight = FontWeight.Medium,
+                color = Color.White
+            )
+        )
+        Icon(
+            painterResource(R.drawable.ic_tooltip_arrow),
+            contentDescription = null,
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .offset(y = 8.dp),
+            tint = LastLoginBadgeColor
         )
     }
 }
@@ -324,6 +386,18 @@ private fun SecretLoginDialog(onDismiss: () -> Unit, onConfirm: () -> Unit) {
 @Composable
 private fun LoginScreenPreview() {
     Scrap2025Theme { LoginScreenContent(onLoginClick = {}, onTestLogin = {}) }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun LastLoginBadgePreview() {
+    Scrap2025Theme {
+        LoginScreenContent(
+            onLoginClick = {},
+            onTestLogin = {},
+            lastLoginSnsType = KAKAO
+        )
+    }
 }
 
 @Preview

--- a/app/src/main/java/com/scrap2025/scrap2025/ui/login/screens/LoginScreen.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/login/screens/LoginScreen.kt
@@ -22,6 +22,7 @@ fun LoginScreen(
 ) {
     val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsState()
+    val lastLoginSnsType by viewModel.lastLoginSnsType.collectAsState()
 
     LaunchedEffect(uiState) {
         if (uiState == LoginUiState.Success) {
@@ -38,6 +39,7 @@ fun LoginScreen(
                     viewModel.login(snsType) { provider -> provider.login(context) }
                 },
                 onTestLogin = { viewModel.loginWithTestToken() },
+                lastLoginSnsType = lastLoginSnsType,
                 modifier = modifier
             )
         }

--- a/app/src/main/java/com/scrap2025/scrap2025/ui/theme/Color.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/ui/theme/Color.kt
@@ -33,6 +33,9 @@ val LightFavoriteColor = Color(0xFFFFF9DB)
 val WarningColor = Color(0xFFFF0000)
 val CautionColor = Color(0xFFFF7A00)
 
+// Login Badge
+val LastLoginBadgeColor = Color(0xFFFF4444)
+
 // Dark Mode Colors
 val DarkModeBackgroundColor = Color(0xFF2F2F2F)
 val DarkModeMainColor = Color(0xFF404040)

--- a/app/src/main/java/com/scrap2025/scrap2025/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/com/scrap2025/scrap2025/viewmodel/LoginViewModel.kt
@@ -3,14 +3,17 @@ package com.scrap2025.scrap2025.viewmodel
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.scrap2025.scrap2025.data.local.PreferencesManager
 import com.scrap2025.scrap2025.data.remote.auth.social.SocialLoginProvider
 import com.scrap2025.scrap2025.model.enums.SnsType
 import com.scrap2025.scrap2025.repository.AuthRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 sealed class LoginUiState {
@@ -28,10 +31,14 @@ class LoginViewModel
 @Inject
 constructor(
     private val authRepository: AuthRepository,
-    private val socialLoginProviders: Map<SnsType, @JvmSuppressWildcards SocialLoginProvider>
+    private val socialLoginProviders: Map<SnsType, @JvmSuppressWildcards SocialLoginProvider>,
+    private val preferencesManager: PreferencesManager
 ) : ViewModel() {
     private val _uiState = MutableStateFlow<LoginUiState>(LoginUiState.Idle)
     val uiState: StateFlow<LoginUiState> = _uiState.asStateFlow()
+
+    val lastLoginSnsType: StateFlow<SnsType?> = preferencesManager.lastLoginSnsType
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
 
     companion object {
         private const val TAG = "LoginViewModel"

--- a/app/src/main/res/drawable/ic_tooltip_arrow.xml
+++ b/app/src/main/res/drawable/ic_tooltip_arrow.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="8dp"
+    android:viewportWidth="16"
+    android:viewportHeight="8">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M0,0 L8,8 L16,0 Z" />
+</vector>


### PR DESCRIPTION
Closes #165

## Summary
- 마지막으로 로그인한 소셜 계정(카카오/네이버) 정보를 로그아웃 후에도 유지하고 로그인 화면에 표시
- 해당 버튼 위에 말풍선 배지("마지막으로 로그인한 계정")를 플로팅 스타일로 표시

## Changes
- **`PreferencesManager`** — `lastLoginSnsType` Flow 및 `saveLastLoginSnsType()` 추가 (세션 토큰과 별도 저장으로 로그아웃 후에도 유지)
- **`AuthRepositoryImpl`** — 로그인 성공 시 `PreferencesManager.saveLastLoginSnsType()` 호출
- **`LoginViewModel`** — `lastLoginSnsType: StateFlow<SnsType?>` 노출
- **`LoginScreen`** — `lastLoginSnsType` 수집 후 `LoginScreenContent`에 전달
- **`LoginScreenContent`** — `SocialLoginButton` 컴포저블로 통합, 배지 표시 로직 포함
- **`Color.kt`** — `LastLoginBadgeColor` 추가
- **`ic_tooltip_arrow.xml`** — 말풍선 하단 삼각형 벡터 drawable 추가
- **`.editorconfig`** — 와일드카드 import 및 trailing comma ktlint 허용 설정 추가

## Test plan
- [ ] 카카오 로그인 후 로그아웃 → 로그인 화면에서 카카오 버튼 위 배지 확인
- [ ] 네이버 로그인 후 로그아웃 → 로그인 화면에서 네이버 버튼 위 배지 확인
- [ ] 앱 재실행 후에도 배지 유지 확인
- [ ] 최초 설치 시 배지 미표시 확인
- [ ] 계정 전환 시 배지가 새 계정으로 이동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)